### PR TITLE
add circle-ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,4 +33,4 @@ jobs:
           name: Execute tests
           command: |
             apk --no-cache add make
-            make docker-build-test
+            make docker-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+orbs:
+  architect: giantswarm/architect@0.13.0
+
+workflows:
+  test:
+    jobs:
+      - run-tests
+
+      - architect/push-to-docker:
+          name: push-app-build-suite-to-quay
+          image: "quay.io/giantswarm/app-build-suite"
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
+          filters:
+            # Needed to trigger job also on git tag.
+            tags:
+              only: /^v.*/
+
+jobs:
+  run-tests:
+    executor: architect/architect
+    steps:
+      - checkout
+
+      - setup_remote_docker
+
+      - run:
+          name: Execute tests
+          command: |
+            make docker-build-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,4 +30,5 @@ jobs:
       - run:
           name: Execute tests
           command: |
+            apk --no-cache add make
             make docker-build-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ workflows:
 
       - architect/push-to-docker:
           name: push-app-build-suite-to-quay
+          requires:
+            - run-tests
           context: architect
           image: "quay.io/giantswarm/app-build-suite"
           username_envar: "QUAY_USERNAME"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
 
       - architect/push-to-docker:
           name: push-app-build-suite-to-quay
+          context: architect
           image: "quay.io/giantswarm/app-build-suite"
           username_envar: "QUAY_USERNAME"
           password_envar: "QUAY_PASSWORD"


### PR DESCRIPTION
Draft PR setting up circle CI testing & docker push to quay

Whats not ideal: Container build is basically done twice. Circle creates separate container build environments for each `setup_remote_docker` for each build step. 

Possible solutions could be:
- Test and push in the same step. IMO its important that container tags should follow the scheme used by architect
- Don't test with `docker run`. Utilize the docker executor with their [python images](https://circleci.com/docs/2.0/circleci-images/#python)