### PR TITLE
Update binaries in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM quay.io/giantswarm/alpine:3.12 AS binaries
 
-ARG HELM_VER="3.3.4"
-ARG KUBECTL_VER="1.18.9"
-ARG CT_VER="3.1.1"
+ARG HELM_VER="3.4.2"
+ARG KUBECTL_VER="1.20.1"
+ARG CT_VER="3.3.1"
 ARG APPTESTCTL_VER="0.5.2"
 
 RUN apk add --no-cache ca-certificates curl \


### PR DESCRIPTION
This PR updates the versions of helm, kubectl and ct in the container image.

I think the most important one is helm. I've seen an error like this: `Error: looks like "https://kubernetes-charts.storage.googleapis.com/" is not a valid chart repository or cannot be reached: failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden` in multiple repositories.