### PR TITLE
enable all jobs for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,12 @@ orbs:
 workflows:
   test:
     jobs:
-      - run-tests
+      - run-tests:
+          name: run-tests
+          filters:
+            # Needed to trigger job also on git tag.
+            tags:
+              only: /^v.*/
 
       - architect/push-to-docker:
           name: push-app-build-suite-to-quay
@@ -26,6 +31,10 @@ workflows:
           name: augment-circleci-dockerfile
           requires:
             - push-app-build-suite-to-quay
+          filters:
+            # Needed to trigger job also on git tag.
+            tags:
+              only: /^v.*/
 
       - architect/push-to-docker:
           name: push-app-build-suite-circle-ci-to-quay


### PR DESCRIPTION
It seems CI was not executed for tag 0.1.1..

![image](https://user-images.githubusercontent.com/1494211/102991733-193fa600-451a-11eb-8164-f6f0cbbad1ad.png)

IDK exactly if this will fix this.

My suggestion would be to wait for https://github.com/giantswarm/github/pull/95 because it'll enable the release automation for this repository.