### PR TITLE
Update apptestctl to v0.6.0 to fix problem with re-running tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/giantswarm/alpine:3.12 AS binaries
 ARG HELM_VER="3.4.2"
 ARG KUBECTL_VER="1.20.1"
 ARG CT_VER="3.3.1"
-ARG APPTESTCTL_VER="0.5.2"
+ARG APPTESTCTL_VER="0.6.0"
 
 RUN apk add --no-cache ca-certificates curl \
     && mkdir -p /binaries \


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14666

Includes app-operator v3.0.0 and configures a shorter resync period and TTL for the finalizer cache. This means the TTL that was causing the problem is reduced from 15 mins to 1 min.
