### PR TITLE
Use apptestctl v0.6.1 with chartmuseum wait fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/giantswarm/alpine:3.12 AS binaries
 ARG HELM_VER="3.4.2"
 ARG KUBECTL_VER="1.20.1"
 ARG CT_VER="3.3.1"
-ARG APPTESTCTL_VER="0.6.0"
+ARG APPTESTCTL_VER="0.6.1"
 
 RUN apk add --no-cache ca-certificates curl \
     && mkdir -p /binaries \

--- a/app_build_suite/build_steps/base_test_runner.py
+++ b/app_build_suite/build_steps/base_test_runner.py
@@ -126,7 +126,7 @@ class TestInfoProvider(BuildStep):
 class BaseTestRunner(BuildStep, ABC):
     _apptestctl_bin = "apptestctl"
     _apptestctl_bootstrap_timeout_sec = 180
-    _min_apptestctl_version = "0.6.0"
+    _min_apptestctl_version = "0.6.1"
     _max_apptestctl_version = "1.0.0"
     _app_deployment_timeout_sec = 1800
     _app_deletion_timeout_sec = 600


### PR DESCRIPTION
Towards https://github.com/giantswarm/apptestctl/issues/77

When run against a fresh kind cluster uploading the tarball now succeeds. Fix was to wait for a ready chartmuseum pod.

```
{"caller":"github.com/giantswarm/apptestctl/cmd/bootstrap/runner.go:644","level":"debug","message":"waited for ready `chartmuseum-chartmuseum` deployment","time":"2021-01-11T15:05:05.975651+00:00"}
2021-01-11 15:05:05,988 app_build_suite.build_steps.base_test_runner INFO: App platform components bootstrapped and ready to use.
2021-01-11 15:05:06,049 app_build_suite.build_steps.repositories INFO: Uploading file '/abs/workdir/build/hello-world-app-0.1.2-9b57f4f882cb89760d8a7f7cd8c9d4c5272adb2d.tgz' to chart-museum.
2021-01-11 15:05:06,073 app_build_suite.build_steps.base_test_runner INFO: Creating App CR for app 'hello-world-app' to be deployed in namespace 'default' in version '0.1.2-9b57f4f882cb89760d8a7f7cd8c9d4c5272adb2d'.
```