### PR TITLE
Kind support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+- `kind` is now supported as an internal cluster creation mechanism
+
 ## [0.1.2] - 2021-01-07
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG HELM_VER="3.4.2"
 ARG KUBECTL_VER="1.20.1"
 ARG CT_VER="3.3.1"
 ARG APPTESTCTL_VER="0.6.1"
+ARG DOCKER_VER="20.10.2"
+ARG KIND_VER="0.9.0"
 
 RUN apk add --no-cache ca-certificates curl \
     && mkdir -p /binaries \
@@ -13,7 +15,10 @@ RUN apk add --no-cache ca-certificates curl \
     && curl -SL https://github.com/giantswarm/apptestctl/releases/download/v${APPTESTCTL_VER}/apptestctl-v${APPTESTCTL_VER}-linux-amd64.tar.gz | \
        tar -C /binaries --strip-components 1 -xvzf - apptestctl-v${APPTESTCTL_VER}-linux-amd64/apptestctl \
     && curl -SL https://github.com/helm/chart-testing/releases/download/v${CT_VER}/chart-testing_${CT_VER}_linux_amd64.tar.gz | \
-       tar -C /binaries -xvzf - ct etc/lintconf.yaml etc/chart_schema.yaml && mv /binaries/etc /etc/ct
+       tar -C /binaries -xvzf - ct etc/lintconf.yaml etc/chart_schema.yaml && mv /binaries/etc /etc/ct \
+    && curl -SL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VER}.tgz | \
+       tar -C /binaries --strip-components 1 -xvzf - docker/docker \
+    && curl -SL https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VER}/kind-linux-amd64 -o /binaries/kind
 
 COPY container-entrypoint.sh /binaries
 

--- a/app_build_suite/__main__.py
+++ b/app_build_suite/__main__.py
@@ -80,9 +80,11 @@ def get_default_config_file_path() -> str:
     # this is the only place where we check for command line option directly,
     # as that's the only way to change where we load the file from
     # FIXME: it's also hacky, as it relies on helm pipeline to provide the "-c" option
-    opt = "-c"
+    short_opt = "-c"
+    long_opt = "--chart-dir"
     base_dir = ""
-    if opt in sys.argv:
+    if short_opt in sys.argv or long_opt in sys.argv:
+        opt = short_opt if short_opt in sys.argv else long_opt
         c_ind = sys.argv.index(opt)
         base_dir = sys.argv[c_ind + 1]
     config_path = os.path.join(base_dir, ".abs", "main.yaml")

--- a/app_build_suite/build_steps/base_test_runner.py
+++ b/app_build_suite/build_steps/base_test_runner.py
@@ -279,7 +279,6 @@ class BaseTestRunner(BuildStep, ABC):
             raise TestError(f"Application deployment failed: {e}")
         finally:
             self._delete_app(config, context)
-            self._cluster_manager.release_cluster(self._cluster_info)
 
     def _deploy_chart_as_app(self, config: argparse.Namespace, context: Context) -> None:
         namespace = get_config_value_by_cmd_line_option(

--- a/app_build_suite/build_steps/base_test_runner.py
+++ b/app_build_suite/build_steps/base_test_runner.py
@@ -4,7 +4,7 @@ import os
 import subprocess  # nosec - we need it to execute apptestctl and test framework
 import time
 from abc import ABC, abstractmethod
-from typing import NewType, Set, Optional, List, cast, Callable
+from typing import Set, Optional, List, cast, Callable
 
 import configargparse
 import pykube
@@ -17,16 +17,11 @@ from app_build_suite.build_steps import BuildStepsFilteringPipeline, BuildStep
 from app_build_suite.build_steps.build_step import StepType, STEP_TEST_ALL
 from app_build_suite.build_steps.cluster_manager import ClusterManager
 from app_build_suite.build_steps.repositories import ChartMuseumAppRepository
+from app_build_suite.build_steps.test_stage_helpers import config_option_cluster_type_for_test_type, TestType
 from app_build_suite.cluster_providers.cluster_provider import ClusterInfo, ClusterType
 from app_build_suite.errors import ConfigError, TestError
 from app_build_suite.types import Context
 from app_build_suite.utils.config import get_config_value_by_cmd_line_option
-
-TestType = NewType("TestType", str)
-TEST_SMOKE = TestType("smoke")
-TEST_FUNCTIONAL = TestType("functional")
-TEST_PERFORMANCE = TestType("performance")
-TEST_COMPATIBILITY = TestType("compatibility")
 
 context_key_chart_yaml: str = "chart_yaml"
 context_key_app_cr: str = "app_cr"
@@ -162,7 +157,7 @@ class BaseTestRunner(BuildStep, ABC):
 
     @property
     def _config_cluster_type_attribute_name(self) -> str:
-        return f"--{self._test_type_executed}-tests-cluster-type"
+        return config_option_cluster_type_for_test_type(self._test_type_executed)
 
     @property
     def _config_cluster_config_file_attribute_name(self) -> str:

--- a/app_build_suite/build_steps/cluster_manager.py
+++ b/app_build_suite/build_steps/cluster_manager.py
@@ -64,13 +64,13 @@ class ClusterManager:
         if cluster_type not in self._cluster_providers.keys():
             raise ValueError(f"Unknown cluster type '{cluster_type}'.")
         logger.debug(f"Checking if we already have a ready cluster of {cluster_type} type.")
-        # FIXME: !!! BUG !!! Clusters need to be identified not only by cluster_type, but config file
-        # used to creat them as well!
-        found_clusters = [c for c in self._clusters if c.cluster_type == cluster_type]
+        found_clusters = [
+            c for c in self._clusters if c.cluster_type == cluster_type and c.config_file == cluster_config_file
+        ]
         if len(found_clusters) > 1:
             logger.error(
-                f"Error: {len(found_clusters)} clusters of type {cluster_type} found. This should never"
-                f"happen. Still, I'm able to continue."
+                f"Error: {len(found_clusters)} clusters of type {cluster_type} with config file '{cluster_config_file}'"
+                f" found. This should never happen. Still, I'm able to continue."
             )
         if len(found_clusters) == 1:
             logger.info(
@@ -78,7 +78,10 @@ class ClusterManager:
                 f"'{found_clusters[0].cluster_type}'."
             )
             return found_clusters[0]
-        logger.info(f"Existing cluster of type '{cluster_type}' not found, requesting creation.")
+        logger.info(
+            f"Existing cluster of type '{cluster_type}' with config file '{cluster_config_file}'"
+            f" not found, requesting creation."
+        )
         cluster_info = self._cluster_providers[cluster_type].get_cluster(
             cluster_type, config, config_file=cluster_config_file
         )

--- a/app_build_suite/build_steps/cluster_manager.py
+++ b/app_build_suite/build_steps/cluster_manager.py
@@ -1,10 +1,13 @@
 import argparse
 import logging
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Set
 
 import configargparse
 
+from app_build_suite.build_steps import test_stage_helpers
+from app_build_suite.build_steps.test_stage_helpers import TEST_TYPE_ALL
 from app_build_suite.cluster_providers.cluster_provider import ClusterInfo, ClusterType, ClusterProvider
+from app_build_suite.utils.config import get_config_value_by_cmd_line_option
 
 logger = logging.getLogger(__name__)
 
@@ -33,13 +36,24 @@ class ClusterManager:
     def get_registered_cluster_types(self) -> List[ClusterType]:
         return [k for k in self._cluster_providers.keys()]
 
+    # noinspection PyMethodMayBeStatic
+    def get_used_cluster_types(self, config: argparse.Namespace) -> Set[ClusterType]:
+        used_cluster_types: Set[ClusterType] = set()
+        for test_type in TEST_TYPE_ALL:
+            config_option_cluster_for_test = test_stage_helpers.config_option_cluster_type_for_test_type(test_type)
+            cluster_type_str = get_config_value_by_cmd_line_option(config, config_option_cluster_for_test)
+            if cluster_type_str:
+                used_cluster_types.add(ClusterType(cluster_type_str))
+        return used_cluster_types
+
     def initialize_config(self, config_parser: configargparse.ArgParser) -> None:
         for cluster_type, provider in self._cluster_providers.items():
             logger.debug(f"Initializing configuration of cluster provider for clusters of type {cluster_type}")
             provider.initialize_config(config_parser)
 
     def pre_run(self, config: argparse.Namespace) -> None:
-        for cluster_type, provider in self._cluster_providers.items():
+        for cluster_type in self.get_used_cluster_types(config):
+            provider = self._cluster_providers[cluster_type]
             logger.debug(f"Executing pre-run of cluster provider for clusters of type {cluster_type}")
             provider.pre_run(config)
 
@@ -56,6 +70,7 @@ class ClusterManager:
         return cluster_info
 
     def release_cluster(self, cluster_info: ClusterInfo) -> None:
+        # FIXME: release_cluster is called after every completed test, so shouldn't delete a cluster by definition
         if cluster_info not in self._clusters:
             raise ValueError(f"Cluster {cluster_info} is not registered as managed here.")
         cluster_info.managing_provider.delete_cluster(cluster_info)

--- a/app_build_suite/build_steps/cluster_manager.py
+++ b/app_build_suite/build_steps/cluster_manager.py
@@ -64,6 +64,8 @@ class ClusterManager:
         if cluster_type not in self._cluster_providers.keys():
             raise ValueError(f"Unknown cluster type '{cluster_type}'.")
         logger.debug(f"Checking if we already have a ready cluster of {cluster_type} type.")
+        # FIXME: !!! BUG !!! Clusters need to be identified not only by cluster_type, but config file
+        # used to creat them as well!
         found_clusters = [c for c in self._clusters if c.cluster_type == cluster_type]
         if len(found_clusters) > 1:
             logger.error(

--- a/app_build_suite/build_steps/helm.py
+++ b/app_build_suite/build_steps/helm.py
@@ -338,12 +338,15 @@ class HelmChartBuilder(BuildStep):
                 full_chart_path = os.path.abspath(full_chart_path)
                 # compare our expected chart_file_name with the one returned from helm and fail if differs
                 helm_chart_file_name = os.path.basename(full_chart_path)
-                if helm_chart_file_name != context[context_key_chart_file_name]:
+                if (
+                    context_key_chart_file_name in context
+                    and helm_chart_file_name != context[context_key_chart_file_name]
+                ):
                     raise BuildError(
                         self.name,
                         f"unexpected chart path '{helm_chart_file_name}' != '{context[context_key_chart_file_name]}'",
                     )
-                if full_chart_path != context[context_key_chart_full_path]:
+                if context_key_chart_full_path in context and full_chart_path != context[context_key_chart_full_path]:
                     raise BuildError(
                         self.name,
                         f"unexpected helm build result: path reported in output '{full_chart_path}' "
@@ -566,7 +569,7 @@ class HelmChartYAMLRestorer(BuildStep):
         if config.keep_chart_changes:
             logger.info(f"Skipping restore of {_chart_yaml}.")
             return
-        if context[context_key_changes_made]:
+        if context_key_changes_made in context and context[context_key_changes_made]:
             logger.info(f"Restoring backup {_chart_yaml}.back to {_chart_yaml}")
             chart_yaml_path = os.path.join(config.chart_dir, _chart_yaml)
             shutil.move(chart_yaml_path + ".back", chart_yaml_path)

--- a/app_build_suite/build_steps/pytest.py
+++ b/app_build_suite/build_steps/pytest.py
@@ -12,11 +12,9 @@ from app_build_suite.build_steps.base_test_runner import (
     BaseTestRunnersFilteringPipeline,
     TestInfoProvider,
     BaseTestRunner,
-    TestType,
-    TEST_FUNCTIONAL,
     context_key_chart_yaml,
-    TEST_SMOKE,
 )
+from app_build_suite.build_steps.test_stage_helpers import TestType, TEST_SMOKE, TEST_FUNCTIONAL
 from app_build_suite.build_steps.build_step import StepType, STEP_TEST_FUNCTIONAL, STEP_TEST_SMOKE
 from app_build_suite.build_steps.cluster_manager import ClusterManager
 from app_build_suite.build_steps.helm import context_key_chart_file_name

--- a/app_build_suite/build_steps/test_stage_helpers.py
+++ b/app_build_suite/build_steps/test_stage_helpers.py
@@ -1,0 +1,13 @@
+from typing import NewType
+
+TestType = NewType("TestType", str)
+
+TEST_SMOKE = TestType("smoke")
+TEST_FUNCTIONAL = TestType("functional")
+TEST_PERFORMANCE = TestType("performance")
+TEST_COMPATIBILITY = TestType("compatibility")
+TEST_TYPE_ALL = [TEST_SMOKE, TEST_FUNCTIONAL]
+
+
+def config_option_cluster_type_for_test_type(test_type: TestType) -> str:
+    return f"--{test_type}-tests-cluster-type"

--- a/app_build_suite/cluster_providers/__init__.py
+++ b/app_build_suite/cluster_providers/__init__.py
@@ -1,1 +1,2 @@
 from .external_cluster_provider import ExternalClusterProvider  # noqa: F401
+from .kind_cluster_provider import KindClusterProvider  # noqa: F401

--- a/app_build_suite/cluster_providers/cluster_provider.py
+++ b/app_build_suite/cluster_providers/cluster_provider.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import NewType
+from typing import NewType, Optional
 
 import configargparse
 
@@ -17,7 +17,7 @@ class ClusterInfo:
     cluster_type: ClusterType
     # some cluster providers are used as a proxy to other providers; then the real (end) cluster
     # type should be put here; example: cluster_type = "external", overridden_cluster_type = "kind"
-    overridden_cluster_type: ClusterType
+    overridden_cluster_type: Optional[ClusterType]
     # as defined by cluster provider
     version: str
     # from the real cluster provider

--- a/app_build_suite/cluster_providers/cluster_provider.py
+++ b/app_build_suite/cluster_providers/cluster_provider.py
@@ -26,6 +26,8 @@ class ClusterInfo:
     kube_config_path: str
     # cluster provider instance responsible for managing this cluster (needs forward type declaration)
     managing_provider: "ClusterProvider"
+    # cluster might have an optional config file used to create that cluster
+    config_file: str
 
 
 class ClusterProvider(ABC):

--- a/app_build_suite/cluster_providers/external_cluster_provider.py
+++ b/app_build_suite/cluster_providers/external_cluster_provider.py
@@ -77,6 +77,7 @@ class ExternalClusterProvider(cluster_provider.ClusterProvider):
             cluster_id="unknown",
             kube_config_path=self.__kubeconfig_path,
             managing_provider=self,
+            config_file="",
         )
 
     def delete_cluster(self, cluster_info: cluster_provider.ClusterInfo):

--- a/app_build_suite/cluster_providers/kind_cluster_provider.py
+++ b/app_build_suite/cluster_providers/kind_cluster_provider.py
@@ -50,8 +50,10 @@ class KindClusterProvider(cluster_provider.ClusterProvider):
         kube_config_path = self.__get_kube_config_from_name(cluster_name)
         kind_args = [self._kind_bin, "create", "cluster", "--name", cluster_name, "--kubeconfig", kube_config_path]
         logger.info(f"Creating KinD cluster with ID '{cluster_name}'...")
+        config_file = ""
         if "config_file" in kwargs and kwargs["config_file"]:
-            kind_args.extend(["--config", kwargs["config_file"]])
+            config_file = kwargs["config_file"]
+            kind_args.extend(["--config", config_file])
         run_res = subprocess.run(kind_args, capture_output=True, text=True)  # nosec
         logger.debug(run_res.stderr)
         if run_res.returncode != 0:
@@ -66,6 +68,7 @@ class KindClusterProvider(cluster_provider.ClusterProvider):
             cluster_id=cluster_name,
             kube_config_path=kube_config_path,
             managing_provider=self,
+            config_file=config_file,
         )
 
     def delete_cluster(self, cluster_info: cluster_provider.ClusterInfo):

--- a/app_build_suite/cluster_providers/kind_cluster_provider.py
+++ b/app_build_suite/cluster_providers/kind_cluster_provider.py
@@ -1,0 +1,89 @@
+import argparse
+import logging
+import os
+import subprocess  # nosec
+import uuid
+
+import configargparse
+
+from app_build_suite.cluster_providers import cluster_provider
+from app_build_suite.errors import ConfigError, TestError
+from app_build_suite.utils import files
+
+logger = logging.getLogger(__name__)
+
+ClusterTypeKind = cluster_provider.ClusterType("kind")
+
+
+class KindClusterProvider(cluster_provider.ClusterProvider):
+    key_config_option_kind_config_path = "--kind-cluster-config-path"
+    _kind_bin = "kind"
+    _kind_min_version = "0.9.0"
+    _kind_max_version = "1.0.0"
+
+    @property
+    def provided_cluster_type(self) -> cluster_provider.ClusterType:
+        return ClusterTypeKind
+
+    def initialize_config(self, config_parser: configargparse.ArgParser) -> None:
+        config_parser.add_argument(
+            self.key_config_option_kind_config_path,
+            required=False,
+            help="A path to the kind config file that provides details for configuring kind cluster",
+        )
+
+    def pre_run(self, config: argparse.Namespace) -> None:
+        if config.kind_cluster_config_path and not os.path.isfile(config.external_cluster_kubeconfig_path):
+            raise ConfigError(
+                self.key_config_option_kind_config_path,
+                f"Kind config file {config.external_cluster_kubeconfig_path} not found.",
+            )
+        # verify if binary present
+        files.assert_binary_present_in_path(self.__class__.__name__, self._kind_bin)
+        # verify version
+        run_res = subprocess.run([self._kind_bin, "version"], capture_output=True)  # nosec
+        version_line = str(run_res.stdout.splitlines()[0], "utf-8")
+        version = version_line.split(" ")[1].strip()
+        config.assert_version_in_range(
+            self.__class__.__name__, self._kind_bin, version, self._kind_min_version, self._kind_max_version
+        )
+
+    @staticmethod
+    def __get_kube_config_from_name(name: str) -> str:
+        return f"{name}.kube.config"
+
+    def get_cluster(
+        self, cluster_type: cluster_provider.ClusterType, config: argparse.Namespace, **kwargs
+    ) -> cluster_provider.ClusterInfo:
+        cluster_name = str(uuid.uuid4())
+        kube_config_path = self.__get_kube_config_from_name(cluster_name)
+        kind_args = [self._kind_bin, "create", "cluster", "--name", cluster_name, "--kubeconfig", kube_config_path]
+        logger.info(f"Creating KinD cluster with ID '{cluster_name}'...")
+        if config.kind_cluster_config_path:
+            kind_args.extend(["--config", config.kind_cluster_config_path])
+        run_res = subprocess.run(kind_args, capture_output=True, stderr=subprocess.STDOUT, text=True)  # nosec
+        logger.debug(run_res.stdout)
+        if run_res.returncode != 0:
+            raise TestError(f"Error when creating KinD cluster. Exit code is: {run_res.returncode}")
+        cluster_version_line = run_res.stdout.splitlines()[1]
+        cluster_version = cluster_version_line.split(":)")[1].strip()
+        logger.info("KinD cluster started successfully")
+        return cluster_provider.ClusterInfo(
+            cluster_type=self.provided_cluster_type,
+            overridden_cluster_type=None,
+            version=cluster_version,
+            cluster_id=cluster_name,
+            kube_config_path=kube_config_path,
+            managing_provider=self,
+        )
+
+    def delete_cluster(self, cluster_info: cluster_provider.ClusterInfo):
+        logger.info(f"Deleting KinD cluster with ID '{cluster_info.cluster_id}'...")
+        kube_config_path = self.__get_kube_config_from_name(cluster_info.cluster_id)
+        kind_args = [self._kind_bin, "delete", "cluster", "--name", cluster_info.cluster_id]
+        run_res = subprocess.run(kind_args, capture_output=True, stderr=subprocess.STDOUT, text=True)  # nosec
+        logger.debug(run_res.stdout)
+        if run_res.returncode != 0:
+            raise TestError(f"Error when deleting KinD cluster. Exit code is: {run_res.returncode}")
+        os.remove(kube_config_path)
+        logger.info("KinD cluster deleted successfully")

--- a/app_build_suite/utils/config.py
+++ b/app_build_suite/utils/config.py
@@ -1,6 +1,10 @@
 import argparse
 from typing import Any
 
+import semver
+
+from app_build_suite.errors import ValidationError
+
 
 def get_config_attribute_from_cmd_line_option(cmd_line_opt: str) -> str:
     return cmd_line_opt.lstrip("-").replace("-", "_")
@@ -8,3 +12,33 @@ def get_config_attribute_from_cmd_line_option(cmd_line_opt: str) -> str:
 
 def get_config_value_by_cmd_line_option(config: argparse.Namespace, cmd_line_opt: str) -> Any:
     return getattr(config, get_config_attribute_from_cmd_line_option(cmd_line_opt))
+
+
+def assert_version_in_range(
+    check_source_name: str, app_name: str, version: str, min_version: str, max_version_exc: str
+) -> None:
+    """
+    Checks if the given app_name with a string version falls in between specified min and max
+    versions (min_version <= version < max_version). Raises ValidationError.
+    :param check_source_name: The name of the component making the check (for clear exception source).
+    :param app_name: The name of the app (used just for logging purposes).
+    :param version: The version string (semver, might start with optional 'v' prefix).
+    :param min_version: proper semver version string to check for (includes this version)
+    :param max_version_exc: proper semver version string to check for (excludes this version)
+    :return:
+    """
+    if version.startswith("v"):
+        version = version[1:]
+    parsed_ver = semver.VersionInfo.parse(version)
+    parsed_min_version = semver.VersionInfo.parse(min_version)
+    parsed_max_version = semver.VersionInfo.parse(max_version_exc)
+    if parsed_ver < parsed_min_version:
+        raise ValidationError(
+            check_source_name,
+            f"Min version '{min_version}' of '{app_name}' is required, '{parsed_ver}' found.",
+        )
+    if parsed_ver >= parsed_max_version:
+        raise ValidationError(
+            check_source_name,
+            f"Version '{parsed_ver}' of '{app_name}' is detected, but lower than {max_version_exc} is required.",
+        )

--- a/app_build_suite/utils/files.py
+++ b/app_build_suite/utils/files.py
@@ -1,5 +1,8 @@
 """Module with file utils"""
 import hashlib
+import shutil
+
+from app_build_suite.errors import ValidationError
 
 
 def get_file_sha256(filename: str) -> str:
@@ -12,3 +15,17 @@ def get_file_sha256(filename: str) -> str:
         file_bytes = f.read()
         readable_hash = hashlib.sha256(file_bytes).hexdigest()
         return readable_hash
+
+
+def assert_binary_present_in_path(check_source_name: str, bin_name: str) -> None:
+    """
+    Checks if binary is available in the system. Raises ValidationError if not found.
+    :param check_source_name: The name of the component making the check (for clear exception source).
+    :param bin_name: The name of the binary executable.
+    :return: None.
+    """
+    if shutil.which(bin_name) is None:
+        raise ValidationError(
+            check_source_name,
+            f"Can't find {bin_name} executable. Please make sure it's installed.",
+        )

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -21,8 +21,9 @@ if [ $# -eq 1 ] && [ "$1" == "versions" ]; then
 fi
 
 if [ "${USE_UID:-0}" -ne 0 ] && [ "${USE_GID:-0}" -ne 0 ]; then
-  groupadd -f -g "$USE_UID" abs
-  useradd -g "$USE_GID" -M -l -u "$USE_UID" abs -d "$ABS_DIR" -s /bin/bash || true
+  groupadd -f -g "$USE_GID" abs
+  groupadd -f -g "$DOCKER_GID" docker
+  useradd -g "$USE_GID" -G docker -M -l -u "$USE_UID" abs -d "$ABS_DIR" -s /bin/bash || true
 fi
 
 chown -R "$USE_UID":"$USE_GID" "$ABS_DIR"

--- a/dabs.sh
+++ b/dabs.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+DABS_TAG=${DABS_TAG:-"latest"}
+
 docker run -it --rm \
   -e USE_UID="$(id -u "${USER}")" \
   -e USE_GID="$(id -g "${USER}")" \
@@ -7,4 +9,4 @@ docker run -it --rm \
   -v "$(pwd)":/abs/workdir/ \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --network host \
-  quay.io/giantswarm/app-build-suite:latest "$@"
+  "quay.io/giantswarm/app-build-suite:${DABS_TAG}" "$@"

--- a/dabs.sh
+++ b/dabs.sh
@@ -3,6 +3,8 @@
 docker run -it --rm \
   -e USE_UID="$(id -u "${USER}")" \
   -e USE_GID="$(id -g "${USER}")" \
+  -e DOCKER_GID="$(getent group docker | cut -d: -f3)" \
   -v "$(pwd)":/abs/workdir/ \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   --network host \
   quay.io/giantswarm/app-build-suite:latest "$@"

--- a/examples/apps/hello-world-app/Chart.yaml
+++ b/examples/apps/hello-world-app/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
-  application.giantswarm.io/metadata: http://localhost/hello-world-app-0.1.2-afa16c6818f4330aa3ce8a70d04118a6a7b4aa44.tgz-meta/main.yaml
+  application.giantswarm.io/metadata: http://localhost/hello-world-app-0.1.2-5e556160a1559310ba4d531c68f86be576ba349d.tgz-meta/main.yaml
   application.giantswarm.io/readme: https://raw.githubusercontent.com/giantswarm/hello-world-app/v0.0.1/README.md
-  application.giantswarm.io/values-schema: http://localhost/hello-world-app-0.1.2-afa16c6818f4330aa3ce8a70d04118a6a7b4aa44.tgz-meta/values.schema.json
+  application.giantswarm.io/values-schema: http://localhost/hello-world-app-0.1.2-5e556160a1559310ba4d531c68f86be576ba349d.tgz-meta/values.schema.json
 apiVersion: v1
 appVersion: v0.0.1
 description: A chart that deploys a basic hello world site and lets you test values
@@ -17,4 +17,4 @@ restrictions:
 sources:
 - https://github.com/giantswarm/hello-world-app
 upstreamChartURL: https://github.com/giantswarm/hello-world-app
-version: 0.1.2-afa16c6818f4330aa3ce8a70d04118a6a7b4aa44
+version: 0.1.2-5e556160a1559310ba4d531c68f86be576ba349d


### PR DESCRIPTION
This PR:

- adds support for creating `kind` clusters internally, for more complex CI/CD scenarios
- fixes some issues around how ClusterManager works
- fixes some bugs around checking keys in `context`
- fixes a bug when `--chart-dir` was used instead of short option `-c`