### PR TITLE
Fix container tag in dabs sh

### DIFF
--- a/Makefile.abs.mk
+++ b/Makefile.abs.mk
@@ -31,7 +31,7 @@ release_ver_to_code:
 	echo "build_ver = \"${TAG}\"\n" > app_build_suite/version.py
 	$(eval IMG_VER := ${TAG})
 	cp dabs.sh dabs.sh.back
-	sed -i "s/latest/${TAG}/" dabs.sh
+	bash -c 'sed -i "s/latest/$${TAG#v}/" dabs.sh'
 
 # Build the docker image from locally built binary
 docker-build: docker-build-ver docker-build-image

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -92,3 +92,15 @@ As an example, please have a look at
 ## Tests
 
 We encourage adding tests. Execute them with `make docker-test`
+
+## Releases
+
+At this point, this repository does not make use of the release automation implemented in GitHub actions.
+
+To create a release, switch to the `master` branch, make sure everything you want to have in your release is commited and documented in the CHANGELOG.md file and your git stage is clean. Now execute:
+
+    make release TAG=vX.Y.Z
+
+This will prepare the files in the repository, commit them and create a new git tag. Review the created commits. When satisfied, publish the new release with:
+
+    git push --tags origin master

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -103,4 +103,4 @@ To create a release, switch to the `master` branch, make sure everything you wan
 
 This will prepare the files in the repository, commit them and create a new git tag. Review the created commits. When satisfied, publish the new release with:
 
-    git push --tags origin master
+    git push origin vX.Y.Z


### PR DESCRIPTION
This PR strips away the leadig `v` from the given tag when executing `make release TAG=vX.Y.Z`.

I've checked several repositories in the giantswarm organization and it seems git tags always have a leading `v` but container image tags do not. So this is the most sane way to fix this issue.