### PR TITLE
Multiple fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+- fix: loading the config file from the root of current working dir
+
 ## [0.1.4] - 2021-01-14
 
 - fixed release process to correctly attach `dabs.sh` as build artefact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 ## [Unreleased]
 
 - fix: loading the config file from the root of current working dir
+- change: `step_unit` name was misleading, renamed now to `step_validate`
+- note: you can safely add `chart-dir` option to the config file, if the file is placed in work dir root
 
 ## [0.1.4] - 2021-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
-- fix: loading the config file from the root of current working dir
-- change: `step_unit` name was misleading, renamed now to `step_validate`
-- note: you can safely add `chart-dir` option to the config file, if the file is placed in work dir root
+### Changes
 
+- Breaking: `step_unit` name was misleading, renamed now to `step_validate`
+- fix: loading the config file from the root of current working dir. Note: you can safely add `chart-dir` option to the config file, if the file is placed in work dir root
 ## [0.1.4] - 2021-01-14
 
 - fixed release process to correctly attach `dabs.sh` as build artefact

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,10 @@ COPY app_build_suite/ ${ABS_DIR}/app_build_suite/
 
 WORKDIR $ABS_DIR/workdir
 
+# we assume the user will be using UID==1000 and GID=1000; if that's not true, we'll run `chown`
+# in the container's startup script
+RUN chown -R 1000:1000 $ABS_DIR
+
 ENTRYPOINT ["container-entrypoint.sh"]
 
 CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -230,8 +230,9 @@ priority, these are:
 
 - command line arguments,
 - environment variables,
-- config file (default config file is `.abs/main.yaml` and it's searched in the running directory or the
-  directory specified with `-c` option).
+- config file (`abs` tries first to load the config file from the chart's directory `.abs/main.yaml` file; if
+  it doesn't exist, then it tries to load the default config file from the current working directory's
+  `.abs.main.yaml`).
 
 When you run `./dabs.sh -h` it shows you command line options and the relevant environment variables names. Options
 for a config file are the same as for command line, just with truncated leading `--`. You can check

--- a/app_build_suite/__main__.py
+++ b/app_build_suite/__main__.py
@@ -82,12 +82,18 @@ def get_default_config_file_path() -> str:
     # FIXME: it's also hacky, as it relies on helm pipeline to provide the "-c" option
     short_opt = "-c"
     long_opt = "--chart-dir"
-    base_dir = ""
+    base_dir = os.getcwd()
+    charts_config_path = ""
     if short_opt in sys.argv or long_opt in sys.argv:
         opt = short_opt if short_opt in sys.argv else long_opt
         c_ind = sys.argv.index(opt)
-        base_dir = sys.argv[c_ind + 1]
-    config_path = os.path.join(base_dir, ".abs", "main.yaml")
+        chart_dir = sys.argv[c_ind + 1]
+        charts_config_path = os.path.join(base_dir, chart_dir, ".abs", "main.yaml")
+    if os.path.isfile(charts_config_path):
+        config_path = charts_config_path
+    else:
+        config_path = os.path.join(base_dir, ".abs", "main.yaml")
+    logger.debug(f"Using {config_path} as configuration file path.")
     return config_path
 
 

--- a/app_build_suite/build_steps/build_step.py
+++ b/app_build_suite/build_steps/build_step.py
@@ -17,7 +17,7 @@ STEP_ALL = StepType("all")
 STEP_BUILD = StepType("build")
 STEP_METADATA = StepType("metadata")
 STEP_TEST_ALL = StepType("test_all")
-STEP_TEST_UNIT = StepType("test_unit")
+STEP_VALIDATE = StepType("test_validate")
 STEP_TEST_SMOKE = StepType("test_smoke")
 STEP_TEST_FUNCTIONAL = StepType("test_functional")
 STEP_TEST_PERFORMANCE = StepType("test_performance")
@@ -27,7 +27,7 @@ ALL_STEPS = {
     STEP_BUILD,
     STEP_METADATA,
     STEP_TEST_ALL,
-    STEP_TEST_UNIT,
+    STEP_VALIDATE,
     STEP_TEST_SMOKE,
     STEP_TEST_FUNCTIONAL,
     STEP_TEST_PERFORMANCE,

--- a/app_build_suite/build_steps/helm.py
+++ b/app_build_suite/build_steps/helm.py
@@ -18,7 +18,7 @@ from app_build_suite.build_steps.build_step import (
     StepType,
     STEP_BUILD,
     ALL_STEPS,
-    STEP_TEST_UNIT,
+    STEP_VALIDATE,
     BuildStepsFilteringPipeline,
     STEP_METADATA,
 )
@@ -161,7 +161,7 @@ class HelmChartToolLinter(BuildStep):
 
     @property
     def steps_provided(self) -> Set[StepType]:
-        return {STEP_TEST_UNIT}
+        return {STEP_VALIDATE}
 
     _ct_bin = "ct"
     _min_ct_version = "3.1.0"

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -17,6 +17,8 @@ if [ $# -eq 1 ] && [ "$1" == "versions" ]; then
   echo
   echo "-> apptestctl:"
   apptestctl version
+  echo "-> kind:"
+  kind version
   exit 0
 fi
 
@@ -26,5 +28,7 @@ if [ "${USE_UID:-0}" -ne 0 ] && [ "${USE_GID:-0}" -ne 0 ]; then
   useradd -g "$USE_GID" -G docker -M -l -u "$USE_UID" abs -d "$ABS_DIR" -s /bin/bash || true
 fi
 
-chown -R "$USE_UID":"$USE_GID" "$ABS_DIR"
+if [ "${USE_UID:-0}" -ne 1000 ] || [ "${USE_GID:-0}" -ne 1000 ]; then
+  chown -R "$USE_UID":"$USE_GID" "$ABS_DIR"
+fi
 sudo --preserve-env=PYTHONPATH,PATH -g "#$USE_GID" -u "#$USE_UID" -- python -m app_build_suite "$@"


### PR DESCRIPTION
- fix loading config file from the work dir root
- rename 'step_unit' to `step_validation` as the name was misleading

Note: it's possible to use `chart-dir` option from a config file if the file is in working dir's root