### PR TITLE
Add 'compatibleProviders' to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
-### Added
+### Changed
 
 - in metadata files, `dateCreated` is now formated the same way as in `index.yaml` created by helm
+
+### Fixed
+
+- `compatibleProviders` is now added to `ct`'s schema file and is correctly validated
 
 ## [0.1.7] - 2021-02-03
 

--- a/examples/apps/hello-world-app/Chart.yaml
+++ b/examples/apps/hello-world-app/Chart.yaml
@@ -14,6 +14,7 @@ restrictions:
   fixedNamespace: helloworld
   gpuInstances: false
   namespaceSingleton: true
+  compatibleProviders: [aws,azure]
 sources:
 - https://github.com/giantswarm/hello-world-app
 upstreamChartURL: https://github.com/giantswarm/hello-world-app

--- a/examples/apps/hello-world-app/Chart.yaml
+++ b/examples/apps/hello-world-app/Chart.yaml
@@ -14,7 +14,7 @@ restrictions:
   fixedNamespace: helloworld
   gpuInstances: false
   namespaceSingleton: true
-  compatibleProviders: [aws,azure]
+  compatibleProviders: [aws, azure]
 sources:
 - https://github.com/giantswarm/hello-world-app
 upstreamChartURL: https://github.com/giantswarm/hello-world-app

--- a/resources/ct_schemas/gs_metadata_chart_schema.yaml
+++ b/resources/ct_schemas/gs_metadata_chart_schema.yaml
@@ -24,6 +24,7 @@ gs-restrictions:
   namespaceSingleton: bool(required=False)
   fixedNamespace: str(required=False)
   gpuInstances: bool(required=False)
+  compatibleProviders: list(str(), required=False)
 ---
 maintainer:
   name: str()

--- a/testrunner.Dockerfile
+++ b/testrunner.Dockerfile
@@ -16,6 +16,7 @@ COPY run-tests-in-docker.sh .
 COPY Pipfile .
 COPY Pipfile.lock .
 COPY tests/ tests/
+COPY examples/ examples/
 COPY .git/ ./.git/
 RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy --clear --dev
 RUN pipenv run pre-commit install-hooks

--- a/tests/build_steps/res_test_helm/Chart.yaml
+++ b/tests/build_steps/res_test_helm/Chart.yaml
@@ -16,3 +16,4 @@ restrictions:
   namespaceSingleton: true
   fixedNamespace: helloworld
   gpuInstances: false
+  compatibleProviders: [aws,azure]

--- a/tests/build_steps/res_test_helm/main.yaml
+++ b/tests/build_steps/res_test_helm/main.yaml
@@ -7,6 +7,7 @@ restrictions:
   fixedNamespace: helloworld
   gpuInstances: false
   namespaceSingleton: true
+  compatibleProviders: [aws,azure]
 upstreamChartURL: https://github.com/giantswarm/hello-world-app
 annotations:
   application.giantswarm.io/values-schema: https://raw.githubusercontent.com/giantswarm/hello-world-app/v0.0.1/helm/hello-world-app/values.schema.json

--- a/tests/e2e/test_example_app.py
+++ b/tests/e2e/test_example_app.py
@@ -1,0 +1,9 @@
+from app_build_suite.__main__ import main
+
+
+def test_build_example_app(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["bogus", "-c", "../../examples/apps/hello-world-app", "--destination", "build/", "--skip-steps", "test_all"],
+    )
+    main()

--- a/tests/e2e/test_example_app.py
+++ b/tests/e2e/test_example_app.py
@@ -4,6 +4,6 @@ from app_build_suite.__main__ import main
 def test_build_example_app(monkeypatch):
     monkeypatch.setattr(
         "sys.argv",
-        ["bogus", "-c", "../../examples/apps/hello-world-app", "--destination", "build/", "--skip-steps", "test_all"],
+        ["bogus", "-c", "examples/apps/hello-world-app", "--destination", "build/", "--skip-steps", "test_all"],
     )
     main()

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -4,4 +4,4 @@ from app_build_suite.utils.files import get_file_sha256
 
 def test_get_sha256() -> None:
     filename = os.path.join(os.path.dirname(__file__), "..", "build_steps", "res_test_helm", "Chart.yaml")
-    assert get_file_sha256(filename) == "a8d675fa9d137613632782c05c2a68c1a6aa3ca463b612504d4be17dfa86325b"
+    assert get_file_sha256(filename) == "d7d772229b6187fd20906bf4c457b2077a630eacdaa193ac11482096e505c1bc"


### PR DESCRIPTION
This PR:

- adds 'compatibleProviders' list of string to `ct`'s schema validation file
- introduces e2e test, where the `app_build_suite` module is invoked to build the example app

Fixes: https://github.com/giantswarm/giantswarm/issues/15809