### PR TITLE
upgrade binary dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 ### Changed
 
 - in metadata files, `dateCreated` is now formated the same way as in `index.yaml` created by helm
+- update binary dependencies:
+  - helm: 3.5.2
+  - chart-test: 3.3.1
+  - apptestctl: 0.7.0
+  - docker: 20.10.3
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine:3.13.2 AS binaries
 
-ARG HELM_VER="3.4.2"
-ARG KUBECTL_VER="1.20.1"
+ARG HELM_VER="3.5.2"
+ARG KUBECTL_VER="1.20.4"
 ARG CT_VER="3.3.1"
-ARG APPTESTCTL_VER="0.6.1"
-ARG DOCKER_VER="20.10.2"
+ARG APPTESTCTL_VER="0.7.0"
+ARG DOCKER_VER="20.10.3"
+# upgrade to kind 0.10.0 held, as it defaults to kubernetes 1.20
 ARG KIND_VER="0.9.0"
 
 RUN apk add --no-cache ca-certificates curl \

--- a/app_build_suite/build_steps/base_test_runner.py
+++ b/app_build_suite/build_steps/base_test_runner.py
@@ -121,7 +121,7 @@ class TestInfoProvider(BuildStep):
 class BaseTestRunner(BuildStep, ABC):
     _apptestctl_bin = "apptestctl"
     _apptestctl_bootstrap_timeout_sec = 180
-    _min_apptestctl_version = "0.6.1"
+    _min_apptestctl_version = "0.7.0"
     _max_apptestctl_version = "1.0.0"
     _app_deployment_timeout_sec = 1800
     _app_deletion_timeout_sec = 600

--- a/app_build_suite/build_steps/helm.py
+++ b/app_build_suite/build_steps/helm.py
@@ -166,7 +166,7 @@ class HelmChartToolLinter(BuildStep):
         return {STEP_VALIDATE}
 
     _ct_bin = "ct"
-    _min_ct_version = "3.1.0"
+    _min_ct_version = "3.3.1"
     _max_ct_version = "4.0.0"
     _metadata_schema = "gs_metadata_chart_schema.yaml"
 
@@ -284,7 +284,7 @@ class HelmRequirementsUpdater(BuildStep):
     """
 
     _helm_bin = "helm"
-    _min_helm_version = "3.2.0"
+    _min_helm_version = "3.5.2"
     _max_helm_version = "4.0.0"
 
     @property


### PR DESCRIPTION
- update binary dependencies:
  - helm: 3.5.2
  - chart-test: 3.3.1
  - apptestctl: 0.7.0
  - docker: 20.10.3

Closes: https://github.com/giantswarm/giantswarm/issues/15925