### PR TITLE
Handle requirements.lock file when updating dependencies for helm lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+### Added
+
+- Support for `requirements.lock` file updating
+
 ## [0.2.1] - 2021-03-02
 
 ### Added


### PR DESCRIPTION
This PR adds handling of `requirements.lock` files for helm charts using `apiVersion: v1` and a `requirements.yaml` file.

Tested this while preparing giantswarm/cert-manager-app#139