### PR TITLE
Update chart-testing schema to not require repository field in chart dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+### Changed
+
+- Update our derived chart schema for chart-testing ahead of a chart-testing release to fix issues
+  with local subcharts requiring a `repository` field.
+
+## [0.2.1] - 2021-03-23
+
 ### Added
 
 - Support for `requirements.lock` file updating

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ RUN apk add --no-cache ca-certificates curl \
        tar -C /binaries --strip-components 1 -xvzf - docker/docker \
     && curl -SL https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VER}/kind-linux-amd64 -o /binaries/kind
 
+# patch the ct chart_schema.yaml file ahead of next release to fix
+# issue https://github.com/helm/chart-testing/issues/324
+# upstream PR https://github.com/helm/chart-testing/pull/300
+RUN sed -i 's|  repository: str()|  repository: str(required=False)|' /etc/ct/chart_schema.yaml
+
 COPY container-entrypoint.sh /binaries
 
 RUN chmod +x /binaries/*

--- a/resources/ct_schemas/gs_metadata_chart_schema.yaml
+++ b/resources/ct_schemas/gs_metadata_chart_schema.yaml
@@ -34,7 +34,7 @@ maintainer:
 dependency:
   name: str()
   version: str()
-  repository: str()
+  repository: str(required=False)
   condition: str(required=False)
   tags: list(str(), required=False)
   enabled: bool(required=False)


### PR DESCRIPTION
Update our derived chart-testing schema ahead of an actual chart-testing
release. Upstream PR: https://github.com/helm/chart-testing/pull/300