### PR TITLE
Remove host network and docker socket mount from dabs script

### DIFF
--- a/dabs.sh
+++ b/dabs.sh
@@ -7,6 +7,4 @@ docker run -it --rm \
   -e USE_GID="$(id -g "${USER}")" \
   -e DOCKER_GID="$(getent group docker | cut -d: -f3)" \
   -v "$(pwd)":/abs/workdir/ \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  --network host \
   "quay.io/giantswarm/app-build-suite:${DABS_TAG}" "$@"


### PR DESCRIPTION
These are not required since `app-test-suite` exists.