### PR TITLE
Refactor Dockerfile + CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,14 +88,38 @@ jobs:
       - checkout
 
       - run:
-          name: Execute tests
+          name: Install test dependencies
           command: |
-            wget -qO- "https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz" | tar -xJv
+            export HELM_VER="3.7.0"
+            export CT_VER="3.4.0"
+            export KUBELINTER_VER="0.2.2"
+
             mkdir ~/bin
+
+            wget -qO - https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz | \
+              tar -C ~/bin --strip-components 1 -xvzf - linux-amd64/helm
+
+            wget -qO- "https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz" | \
+              tar -xJv
             mv "shellcheck-latest/shellcheck" ~/bin/
 
+            wget -qO - https://github.com/helm/chart-testing/releases/download/v${CT_VER}/chart-testing_${CT_VER}_linux_amd64.tar.gz | \
+              tar -C ~/bin -xvzf - ct etc/lintconf.yaml etc/chart_schema.yaml
+            mv ~/bin/etc /etc/ct
+
+            wget -qO - https://github.com/stackrox/kube-linter/releases/download/${KUBELINTER_VER}/kube-linter-linux.tar.gz | \
+              tar -C ~/bin -xvzf -
+
             pipenv install --deploy --clear --dev
+
+      - run:
+          name: Lint code
+          command: |
             pipenv run pre-commit run --all-files
+
+      - run:
+          name: Execute tests
+          command: |
             make test
 
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
       - run:
           name: Execute tests
           command: |
+            wget -qO- "https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz" | tar -xJv && cp "shellcheck-latest/shellcheck" ~/bin/
             pipenv install --deploy --clear --dev
             pipenv run pre-commit run --all-files
             make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
 
             wget -qO - https://github.com/helm/chart-testing/releases/download/v${CT_VER}/chart-testing_${CT_VER}_linux_amd64.tar.gz | \
               tar -C ~/bin -xvzf - ct etc/lintconf.yaml etc/chart_schema.yaml
-            mv ~/bin/etc /etc/ct
+            sudo mv ~/bin/etc /etc/ct
 
             wget -qO - https://github.com/stackrox/kube-linter/releases/download/${KUBELINTER_VER}/kube-linter-linux.tar.gz | \
               tar -C ~/bin -xvzf -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,14 +88,10 @@ jobs:
       - checkout
 
       - run:
-          name: Extract versions from Dockerfile
-          command: |
-            eval $(sed -n 's|ARG|export|p' Dockerfile)
-            sed -n 's|ARG|export|p' Dockerfile
-
-      - run:
           name: Install test dependencies
           command: |
+            eval $(sed -n 's|ARG|export|p' Dockerfile)
+
             mkdir ~/bin
 
             wget -qO - https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz | \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ jobs:
             export HELM_VER="3.7.0"
             export CT_VER="3.4.0"
             export KUBELINTER_VER="0.2.2"
+            export CT_YAMALE_VER="3.0.4"
+            export CT_YAMLLINT_VER="1.25.0"
 
             mkdir ~/bin
 
@@ -111,6 +113,7 @@ jobs:
               tar -C ~/bin -xvzf -
 
             pipenv install --deploy --clear --dev
+            pip install yamllint==${CT_YAMLLINT_VER} yamale==${CT_YAMALE_VER}
 
       - run:
           name: Lint code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,15 +82,17 @@ jobs:
             - "circleci.Dockerfile"
 
   run-tests:
-    machine:
-      image: ubuntu-2004:202010-01
+    docker:
+      - image: cimg/python:3.8.12
     steps:
       - checkout
 
       - run:
           name: Execute tests
           command: |
-            make docker-test-ci
+            pipenv install --deploy --clear --dev
+            pipenv run pre-commit run --all-files
+            make test
 
       - codecov/upload:
           file: .coverage/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       - run:
           name: Execute tests
           command: |
-            make test
+            make test-ci
 
       - codecov/upload:
           file: .coverage/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,10 @@ jobs:
       - run:
           name: Execute tests
           command: |
-            wget -qO- "https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz" | tar -xJv && cp "shellcheck-latest/shellcheck" ~/bin/
+            wget -qO- "https://github.com/koalaman/shellcheck/releases/download/latest/shellcheck-latest.linux.x86_64.tar.xz" | tar -xJv
+            mkdir ~/bin
+            mv "shellcheck-latest/shellcheck" ~/bin/
+
             pipenv install --deploy --clear --dev
             pipenv run pre-commit run --all-files
             make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,14 +88,14 @@ jobs:
       - checkout
 
       - run:
+          name: Extract versions from Dockerfile
+          command: |
+            eval $(sed -n 's|ARG|export|p' Dockerfile)
+            sed -n 's|ARG|export|p' Dockerfile
+
+      - run:
           name: Install test dependencies
           command: |
-            export HELM_VER="3.7.0"
-            export CT_VER="3.4.0"
-            export KUBELINTER_VER="0.2.2"
-            export CT_YAMALE_VER="3.0.4"
-            export CT_YAMLLINT_VER="1.25.0"
-
             mkdir ~/bin
 
             wget -qO - https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
-FROM alpine:3.14.0 AS binaries
+FROM quay.io/giantswarm/python:3.8.12-slim AS binaries
 
 ARG HELM_VER="3.7.0"
 ARG CT_VER="3.4.0"
 ARG KUBELINTER_VER="0.2.2"
 
-RUN apk add --no-cache ca-certificates curl \
+RUN apt-get update && apt-get install --no-install-recommends -y wget \
     && mkdir -p /binaries \
-    && curl -SL https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz | \
+    && wget -qO - https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz | \
        tar -C /binaries --strip-components 1 -xvzf - linux-amd64/helm \
-    && curl -SL https://github.com/helm/chart-testing/releases/download/v${CT_VER}/chart-testing_${CT_VER}_linux_amd64.tar.gz | \
+    && wget -qO - https://github.com/helm/chart-testing/releases/download/v${CT_VER}/chart-testing_${CT_VER}_linux_amd64.tar.gz | \
        tar -C /binaries -xvzf - ct etc/lintconf.yaml etc/chart_schema.yaml && mv /binaries/etc /etc/ct \
-    && curl -SL https://github.com/stackrox/kube-linter/releases/download/${KUBELINTER_VER}/kube-linter-linux.tar.gz | \
+    && wget -qO - https://github.com/stackrox/kube-linter/releases/download/${KUBELINTER_VER}/kube-linter-linux.tar.gz | \
        tar -C /binaries -xvzf -
-
-# patch the ct chart_schema.yaml file ahead of next release to fix
-# issue https://github.com/helm/chart-testing/issues/324
-# upstream PR https://github.com/helm/chart-testing/pull/300
-RUN sed -i 's|  repository: str()|  repository: str(required=False)|' /etc/ct/chart_schema.yaml
 
 COPY container-entrypoint.sh /binaries
 

--- a/Makefile.abs.mk
+++ b/Makefile.abs.mk
@@ -57,6 +57,9 @@ test-docker-run = docker $(test-docker-args) ${IMG}-test:latest
 test:
 	pipenv run python -m pytest $(test-command)
 
+test-ci:
+	pipenv run python -m pytest $(test-command-ci)
+
 docker-test: docker-build-test
 	$(test-docker-run) $(test-command)
 


### PR DESCRIPTION
This PR contains the following changes:

- Use the python image used in the final container build stage to avoid having to pull alpine only for binary download
  - Not much improval in regard of time, but dowloads less data
- Use the `docker` executor instead of `machine` for executing tests in CI
  - Tests run for about 1 minute instead of 4:30

I think these changes will improve the time it takes to execute all CI steps