### PR TITLE
Add push-to-app-catalog github action

### DIFF
--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -1,0 +1,55 @@
+name: 'Push to App Catalog'
+
+on:
+  workflow_call:
+    inputs:
+      app_catalog:
+        required: true
+        type: string
+      chart:
+        required: true
+        type: string
+      organization:
+        required: true
+        type: string
+    secrets:
+      envPAT:
+        required: true
+
+jobs:
+  push_to_app_catalog:
+    name: Push to app catalog
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout app repository
+        uses: actions/checkout@v2
+
+      - name: Checkout app catalog repository
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.organization }}/${{ inputs.app_catalog }}
+          path: app_catalog
+          token: ${{ secrets.PAT }}
+
+      - name: Execute app-build-suite
+        uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
+        with:
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.2
+
+      - name: Update Helm index.yaml
+        run:  |
+          cd app_catalog
+          helm repo index --url https://${{ inputs.organization }}.github.io/${{ inputs.app_catalog }}/ .
+
+      - name: Commit changes to app catalog repository
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: add ${{ inputs.chart }}
+          commit_user_name: app-build-suite
+          repository: app_catalog

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
         with:
-          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -52,7 +52,6 @@ jobs:
           binary: "yq"
           download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}_linux_amd64.tar.gz"
           smoke_test: "${binary} --version"
-          tarball_binary_path: "${binary}_linux_amd64"
           version: "v4.17.2"
 
       - name: Get chart version

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -56,7 +56,7 @@ jobs:
           version: "v4.17.2"
 
       - name: Set version from Chart.yaml
-        run:  echo ::set-output name=version::$(yq e '.version' helm/${{ inputs.chart }}/Chart.yaml)
+        run:  echo "::set-output name=version::$(yq e '.version' helm/${{ inputs.chart }}/Chart.yaml)"
 
       - name: Commit changes to app catalog repository
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
         with:
-          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/${{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/${{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes --replace-chart-version-with-git
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -52,6 +52,7 @@ jobs:
           binary: "yq"
           download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}_linux_amd64.tar.gz"
           smoke_test: "${binary} --version"
+          tarball_binary_path: "yq_linux_amd64"
           version: "v4.17.2"
 
       - name: Get chart version

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
         with:
-          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes=True
 
       - name: Setup Helm
         uses: azure/setup-helm@v1
@@ -46,10 +46,17 @@ jobs:
           cd app_catalog
           helm repo index --url https://${{ inputs.organization }}.github.io/${{ inputs.app_catalog }}/ .
 
+      - name: Install yq
+        uses: giantswarm/install-binary-action@v1.0.0
+        with:
+          binary: "yq"
+          version: "4.17.2"
+          download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}.tar.gz"
+          smoke_test: "${binary} --version"
+
       - name: Get chart version
         run:  |
-          ls -l
-          cat helm/${{ inputs.chart }}/Chart.yaml
+          yq e '.version' helm/${{ inputs.chart }}/Chart.yaml
 
       - name: Commit changes to app catalog repository
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -50,9 +50,8 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "yq"
-          download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}_linux_amd64.tar.gz"
+          download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}_linux_amd64"
           smoke_test: "${binary} --version"
-          tarball_binary_path: "yq_linux_amd64"
           version: "v4.17.2"
 
       - name: Get chart version

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
         with:
-          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes=True
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes true
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -27,8 +27,9 @@ jobs:
       - name: Checkout app catalog repository
         uses: actions/checkout@v2
         with:
-          repository: ${{ inputs.organization }}/${{ inputs.app_catalog }}
           path: app_catalog
+          ref: main
+          repository: ${{ inputs.organization }}/${{ inputs.app_catalog }}
           token: ${{ secrets.envPAT }}
 
       - name: Execute app-build-suite

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
         with:
-          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/${{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
         with:
-          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes=true
 
       - name: Setup Helm
         uses: azure/setup-helm@v1
@@ -45,6 +45,10 @@ jobs:
         run:  |
           cd app_catalog
           helm repo index --url https://${{ inputs.organization }}.github.io/${{ inputs.app_catalog }}/ .
+
+      - name: Get chart version
+        run:  |
+          cat helm/${{ inputs.chart }}/Chart.yaml
 
       - name: Commit changes to app catalog repository
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: ${{ inputs.organization }}/${{ inputs.app_catalog }}
           path: app_catalog
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.envPAT }}
 
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -4,16 +4,20 @@ on:
   workflow_call:
     inputs:
       app_catalog:
+        description: 'Name of the app catalog GitHub repository. E.g. example-catalog'
         required: true
         type: string
       chart:
+        description: 'Name of the chart in the helm directory. E.g. hello-world-app'
         required: true
         type: string
       organization:
+        description: 'Name of the GitHub organization. E.g. example-org'
         required: true
         type: string
     secrets:
       envPAT:
+        description: GitHub Personal Access Token that must be added as secret in the repo.
         required: true
 
 jobs:

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -56,12 +56,13 @@ jobs:
           version: "v4.17.2"
 
       - name: Set version from Chart.yaml
+        id: chart-version
         run:  echo "::set-output name=version::$(yq e '.version' helm/${{ inputs.chart }}/Chart.yaml)"
 
       - name: Commit changes to app catalog repository
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: main
-          commit_message: add ${{ inputs.chart }}-${{ steps.vars.outputs.version }}
+          commit_message: add ${{ inputs.chart }}-${{ steps.chart-version.outputs.version }}
           commit_user_name: app-build-suite
           repository: app_catalog

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -50,8 +50,9 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "yq"
-          download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}_linux_amd64"
+          download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}_linux_amd64.tar.gz"
           smoke_test: "${binary} --version"
+          tarball_binary_path: "*/${binary}_linux_amd64"
           version: "v4.17.2"
 
       - name: Get chart version

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -50,9 +50,10 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "yq"
-          version: "4.17.2"
-          download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}.tar.gz"
+          download_url: "https://github.com/mikefarah/yq/releases/download/${version}/${binary}_linux_amd64.tar.gz"
           smoke_test: "${binary} --version"
+          tarball_binary_path: "${binary}_linux_amd64"
+          version: "v4.17.2"
 
       - name: Get chart version
         run:  |

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
         with:
-          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes true
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -55,14 +55,13 @@ jobs:
           tarball_binary_path: "*/${binary}_linux_amd64"
           version: "v4.17.2"
 
-      - name: Get chart version
-        run:  |
-          yq e '.version' helm/${{ inputs.chart }}/Chart.yaml
+      - name: Set version from Chart.yaml
+        run:  echo ::set-output name=version::$(yq e '.version' helm/${{ inputs.chart }}/Chart.yaml)
 
       - name: Commit changes to app catalog repository
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: main
-          commit_message: add ${{ inputs.chart }}
+          commit_message: add ${{ inputs.chart }}-${{ steps.vars.outputs.version }}
           commit_user_name: app-build-suite
           repository: app_catalog

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Execute app-build-suite
         uses: docker://quay.io/giantswarm/app-build-suite:1.0.4
         with:
-          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog --keep-chart-changes=true
+          args: --chart-dir helm/${{ inputs.chart }} --catalog-base-url "https://${{ inputs.organization }}.github.io/{{ inputs.app_catalog }}/" --destination app_catalog
 
       - name: Setup Helm
         uses: azure/setup-helm@v1
@@ -48,6 +48,7 @@ jobs:
 
       - name: Get chart version
         run:  |
+          ls -l
           cat helm/${{ inputs.chart }}/Chart.yaml
 
       - name: Commit changes to app catalog repository

--- a/.github/workflows/push-to-app-catalog.yaml
+++ b/.github/workflows/push-to-app-catalog.yaml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: app_catalog
-          ref: main
           repository: ${{ inputs.organization }}/${{ inputs.app_catalog }}
           token: ${{ secrets.envPAT }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+- Added
+  - Add `push-to-app-catalog` GitHub Action
+
 - Changed
   - Enabling `kube-linter` verbose output by default
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19941

This adds a reusable github action for building apps using ABS and pushing to a github repo.

I've been testing it with a test [catalog]( https://github.com/rossf7/example-catalog) and a fork of our [hello-world-app](https://github.com/rossf7/hello-world-app/blob/master/.github/workflows/push-to-app-catalog.yaml) and here is an example [run](https://github.com/rossf7/hello-world-app/runs/4940497070?check_suite_focus=true)
 
```yaml
name: 'Push to App Catalog'

on:
  push:
    tags:
      - 'v*'

jobs:
  push_to_app_catalog:
    uses: giantswarm/app-build-suite/.github/workflows/push-to-app-catalog.yaml@github-action
    with:
      app_catalog: example-catalog
      chart: hello-world-app
      organization: rossf7
    secrets:
      envPAT: ${{ secrets.PAT }}
```

