### PR TITLE
Update kube linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
   - Upgrade Helm to 3.8.1
   - Upgrade python to 3.10.3
   - Upgrade chart-testing to 3.5.1
+  - Upgrade kube-linter to 0.2.5
 
 ## [1.0.4] - 2021-09-21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/giantswarm/python:3.10.3-slim AS binaries
 
 ARG HELM_VER="3.8.1"
 ARG CT_VER="3.5.1"
-ARG KUBELINTER_VER="0.2.2"
+ARG KUBELINTER_VER="0.2.5"
 
 RUN apt-get update && apt-get install --no-install-recommends -y wget \
     && mkdir -p /binaries \

--- a/app_build_suite/build_steps/helm.py
+++ b/app_build_suite/build_steps/helm.py
@@ -254,7 +254,7 @@ class KubeLinter(BuildStep):
         return {STEP_STATIC_CHECK}
 
     _kubelinter_bin = "kube-linter"
-    _min_kubelinter_version = "0.2.2"
+    _min_kubelinter_version = "0.2.5"
     _max_kubelinter_version = "0.3.0"
     _default_kubelinter_cfg_file = ".kube-linter.yaml"
 

--- a/examples/apps/hello-world-app/.kube-linter.yaml
+++ b/examples/apps/hello-world-app/.kube-linter.yaml
@@ -1,5 +1,4 @@
 checks:
-  addAllBuiltIn: true
   exclude:
   - "unset-cpu-requirements"
   - "unset-memory-requirements"


### PR DESCRIPTION
Kube-linter updated to 0.2.5. All-in validation disabled in the example app.