### PR TITLE
Add chart dependency support to the team label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following [Se
 
 ## [Unreleased]
 
+- Added
+  - Add support for default teams in team annotation to support chart dependencies.
+
 ## [1.1.2] - 2022-03-25
 
 - Fixed

--- a/app_build_suite/build_steps/giant_swarm_validators/helm.py
+++ b/app_build_suite/build_steps/giant_swarm_validators/helm.py
@@ -48,7 +48,7 @@ class HasTeamLabel:
         + escaped_label
         + r':[ \t]+{{[ \t]*index[ \t]+\.Chart\.Annotations[ \t]+"'
         + escaped_label
-        + r'"[ \t]*\|[ \t]*quote[ \t]*}}[ \t]*'
+        + r'"[ \t]*(\|[ \t]*default[ \t]+\"[a-zA-Z0-9]+\"[ \t]+){0,1}\|[ \t]*quote[ \t]*}}[ \t]*'
     )
 
     def get_check_code(self) -> str:

--- a/docs/helm-build-pipeline.md
+++ b/docs/helm-build-pipeline.md
@@ -61,7 +61,7 @@ Helm build pipeline executes in sequence the following set of steps:
    ([have a look at the code for details](../app_build_suite/build_steps/giant_swarm_validators/helm.py):
    - `HasValuesSchema` - checks if the `values.schema.json` file is present,
    - `HasTeamLabel` - a bit naive check if the team annotation is present (it only checks for the correct definition
-     in `Chart.yaml` and then if the `_templates.yaml` is present and the recommended label is there). Check
+     in `Chart.yaml` and then if the `_templates.yaml` is present and the recommended label is there) or is not empty. Check
      [the example](../examples/apps/hello-world-app/templates/_helpers.yaml) here.
 
    Available config options:

--- a/tests/build_steps/giant_swarm_validators/test_helm_validators.py
+++ b/tests/build_steps/giant_swarm_validators/test_helm_validators.py
@@ -42,6 +42,19 @@ annotations:
    {{- end }}""",
             True,
         ),
+        # case: both files valid, helpers has default team, validation should pass
+        (
+            # Chart.yaml
+            """
+annotations:
+  application.giantswarm.io/team: 'honeybadger'""",
+            # _helpers.yaml
+            """
+   {{- define "hello-world-app.labels" -}}
+   application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "honeybadger" | quote }}
+   {{- end }}""",
+            True,
+        ),
         # case: team annotation present, but has no value; should fail
         (
             # Chart.yaml

--- a/tests/build_steps/giant_swarm_validators/test_helm_validators.py
+++ b/tests/build_steps/giant_swarm_validators/test_helm_validators.py
@@ -51,7 +51,8 @@ annotations:
             # _helpers.yaml
             """
    {{- define "hello-world-app.labels" -}}
-   application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "honeybadger" | quote }}
+   application.giantswarm.io/team: """
+     + """{{ index .Chart.Annotations "application.giantswarm.io/team" | default "honeybadger" | quote }}
    {{- end }}""",
             True,
         ),


### PR DESCRIPTION
Tested [here](https://regex101.com/r/TQDrjZ/1) but it is my first time with Python and regex :D 

We are in dire need of this because we use subcharts a lot and if the annotation is not set on the subchart, the value is empty

@piontec can you take a look pretty please?