### PR TITLE
Remove timestamp, module name, and level from log template

### DIFF
--- a/app_build_suite/__main__.py
+++ b/app_build_suite/__main__.py
@@ -149,7 +149,7 @@ def get_config(steps: List[BuildStep]) -> configargparse.Namespace:
 
 
 def main() -> None:
-    log_format = "%(levelname)s: %(message)s"
+    log_format = "%(message)s"
     logging.basicConfig(format=log_format)
     logging.getLogger().setLevel(logging.INFO)
 

--- a/app_build_suite/__main__.py
+++ b/app_build_suite/__main__.py
@@ -149,7 +149,7 @@ def get_config(steps: List[BuildStep]) -> configargparse.Namespace:
 
 
 def main() -> None:
-    log_format = "%(asctime)s %(name)s %(levelname)s: %(message)s"
+    log_format = "%(levelname)s: %(message)s"
     logging.basicConfig(format=log_format)
     logging.getLogger().setLevel(logging.INFO)
 


### PR DESCRIPTION
Goal: reduce noise, make output easier to read.

FYI: I have no idea whether the change is all it takes. This is untested.

<details>
<summary>Before</summary>

```nohighlight
2022-12-01 13:58:25,458 step_exec_lib.steps INFO: Running pre-run step for HelmBuilderValidator
2022-12-01 13:58:25,458 step_exec_lib.steps INFO: Running pre-run step for GiantSwarmHelmValidator
2022-12-01 13:58:25,460 app_build_suite.build_steps.helm INFO: Running Giant Swarm validator 'C0001: HasTeamLabel'.
2022-12-01 13:58:25,462 app_build_suite.build_steps.helm INFO: Running Giant Swarm validator 'F0001: HasValuesSchema'.
2022-12-01 13:58:25,462 step_exec_lib.steps INFO: Running pre-run step for HelmGitVersionSetter
2022-12-01 13:58:25,463 step_exec_lib.steps INFO: Running pre-run step for HelmRequirementsUpdater
2022-12-01 13:58:25,463 step_exec_lib.utils.processes INFO: Running command:
2022-12-01 13:58:25,463 step_exec_lib.utils.processes INFO: helm version
2022-12-01 13:58:25,492 step_exec_lib.utils.processes INFO: Command executed, exit code: 0.
2022-12-01 13:58:25,492 step_exec_lib.steps INFO: Running pre-run step for HelmChartToolLinter
2022-12-01 13:58:25,493 step_exec_lib.utils.processes INFO: Running command:
2022-12-01 13:58:25,493 step_exec_lib.utils.processes INFO: ct version
2022-12-01 13:58:25,497 step_exec_lib.utils.processes INFO: Command executed, exit code: 0.
2022-12-01 13:58:25,497 app_build_suite.build_steps.helm INFO: Metadata generation was requested, changing default validation schema to 'gs_metadata_chart_schema.yaml'
2022-12-01 13:58:25,497 step_exec_lib.steps INFO: Running pre-run step for KubeLinter
2022-12-01 13:58:25,497 step_exec_lib.utils.processes INFO: Running command:
2022-12-01 13:58:25,497 step_exec_lib.utils.processes INFO: kube-linter version
2022-12-01 13:58:25,524 step_exec_lib.utils.processes INFO: Command executed, exit code: 0.
2022-12-01 13:58:25,525 step_exec_lib.steps INFO: Running pre-run step for HelmChartMetadataPreparer
2022-12-01 13:58:25,527 step_exec_lib.steps INFO: Running pre-run step for HelmChartBuilder
2022-12-01 13:58:25,527 step_exec_lib.utils.processes INFO: Running command:
2022-12-01 13:58:25,527 step_exec_lib.utils.processes INFO: helm version
2022-12-01 13:58:25,553 step_exec_lib.utils.processes INFO: Command executed, exit code: 0.
2022-12-01 13:58:25,553 step_exec_lib.steps INFO: Running pre-run step for HelmChartMetadataFinalizer
2022-12-01 13:58:25,555 step_exec_lib.steps INFO: Running pre-run step for HelmChartYAMLRestorer
2022-12-01 13:58:25,555 step_exec_lib.steps INFO: Running build step for HelmBuilderValidator
2022-12-01 13:58:25,555 step_exec_lib.steps INFO: Running build step for GiantSwarmHelmValidator
2022-12-01 13:58:25,555 step_exec_lib.steps INFO: Running build step for HelmGitVersionSetter
2022-12-01 13:58:25,561 app_build_suite.build_steps.helm INFO: Replacing 'version' with git version '0.4.4-40ddaecc9cb3a4c88ad897026674fda5f016c4dc' in Chart.yaml.
2022-12-01 13:58:25,561 app_build_suite.build_steps.helm INFO: Saving Chart.yaml with version set from git.
2022-12-01 13:58:25,562 step_exec_lib.steps INFO: Running build step for HelmRequirementsUpdater
2022-12-01 13:58:25,562 app_build_suite.build_steps.helm INFO: Updating lockfile(s) with 'helm dependencies update ./helm/cluster-cloud-director'
2022-12-01 13:58:25,562 step_exec_lib.utils.processes INFO: Running command:
2022-12-01 13:58:25,562 step_exec_lib.utils.processes INFO: helm dependencies update ./helm/cluster-cloud-director
2022-12-01 13:58:25,772 step_exec_lib.utils.processes INFO: Command executed, exit code: 0.
2022-12-01 13:58:25,772 step_exec_lib.steps INFO: Running build step for HelmChartToolLinter
2022-12-01 13:58:25,772 app_build_suite.build_steps.helm INFO: Running chart tool linting
2022-12-01 13:58:25,772 step_exec_lib.utils.processes INFO: Running command:
2022-12-01 13:58:25,772 step_exec_lib.utils.processes INFO: ct lint --validate-maintainers=false --charts=./helm/cluster-cloud-director --config=/root/project/./.circleci/ct-config.yaml --chart-yaml-schema=/abs/app_build_suite/build_steps/../../resources/ct_schemas/gs_metadata_chart_schema.yaml
2022-12-01 13:58:28,552 step_exec_lib.utils.processes INFO: Command executed, exit code: 0.
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Linting charts...
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: 
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: ------------------------------------------------------------------------------------------------------------------------
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO:  Charts to be processed:
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: ------------------------------------------------------------------------------------------------------------------------
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO:  cluster-cloud-director => (version: "0.4.4-40ddaecc9cb3a4c88ad897026674fda5f016c4dc", path: "./helm/cluster-cloud-director")
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: ------------------------------------------------------------------------------------------------------------------------
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: 
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: "cluster-catalog" has been added to your repositories
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: "cluster-test-catalog" has been added to your repositories
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Hang tight while we grab the latest from your chart repositories...
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: ...Successfully got an update from the "cluster-catalog" chart repository
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: ...Successfully got an update from the "cluster-test-catalog" chart repository
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Update Complete. ⎈Happy Helming!⎈
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Saving 1 charts
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Downloading cluster-shared from repo https://giantswarm.github.io/cluster-catalog
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Deleting outdated charts
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Linting chart 'cluster-cloud-director => (version: "0.4.4-40ddaecc9cb3a4c88ad897026674fda5f016c4dc", path: "./helm/cluster-cloud-director")'
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Validating /root/project/helm/cluster-cloud-director/Chart.yaml...
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Validation success! 👍
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: 
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: Linting chart with values file 'helm/cluster-cloud-director/ci/ci-values.yaml'...
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: 
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: ==> Linting ./helm/cluster-cloud-director
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: [INFO] Chart.yaml: icon is recommended
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: 
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: 1 chart(s) linted, 0 chart(s) failed
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: coalesce.go:223: warning: destination for nodePools is a table. Ignoring non-table value ([])
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: coalesce.go:175: warning: skipped value for cluster-cloud-director.nodePools: Not a table.
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: coalesce.go:175: warning: skipped value for cluster-cloud-director.nodePools: Not a table.
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: coalesce.go:175: warning: skipped value for cluster-cloud-director.nodePools: Not a table.
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: ------------------------------------------------------------------------------------------------------------------------
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO:  ✔︎ cluster-cloud-director => (version: "0.4.4-40ddaecc9cb3a4c88ad897026674fda5f016c4dc", path: "./helm/cluster-cloud-director")
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: ------------------------------------------------------------------------------------------------------------------------
2022-12-01 13:58:28,552 app_build_suite.build_steps.helm INFO: All charts linted successfully
2022-12-01 13:58:28,552 step_exec_lib.steps INFO: Running build step for KubeLinter
```

</details>

<details>
<summary>After</summary>

```nohighlight
Running pre-run step for HelmBuilderValidator
Running pre-run step for GiantSwarmHelmValidator
Running Giant Swarm validator 'C0001: HasTeamLabel'.
Running Giant Swarm validator 'F0001: HasValuesSchema'.
Running pre-run step for HelmGitVersionSetter
Running pre-run step for HelmRequirementsUpdater
Running command:
helm version
Command executed, exit code: 0.
Running pre-run step for HelmChartToolLinter
Running command:
ct version
Command executed, exit code: 0.
Metadata generation was requested, changing default validation schema to 'gs_metadata_chart_schema.yaml'
Running pre-run step for KubeLinter
Running command:
kube-linter version
Command executed, exit code: 0.
Running pre-run step for HelmChartMetadataPreparer
Running pre-run step for HelmChartBuilder
Running command:
helm version
Command executed, exit code: 0.
Running pre-run step for HelmChartMetadataFinalizer
Running pre-run step for HelmChartYAMLRestorer
Running build step for HelmBuilderValidator
Running build step for GiantSwarmHelmValidator
Running build step for HelmGitVersionSetter
Replacing 'version' with git version '0.4.4-40ddaecc9cb3a4c88ad897026674fda5f016c4dc' in Chart.yaml.
Saving Chart.yaml with version set from git.
Running build step for HelmRequirementsUpdater
Updating lockfile(s) with 'helm dependencies update ./helm/cluster-cloud-director'
Running command:
helm dependencies update ./helm/cluster-cloud-director
Command executed, exit code: 0.
Running build step for HelmChartToolLinter
Running chart tool linting
Running command:
ct lint --validate-maintainers=false --charts=./helm/cluster-cloud-director --config=/root/project/./.circleci/ct-config.yaml --chart-yaml-schema=/abs/app_build_suite/build_steps/../../resources/ct_schemas/gs_metadata_chart_schema.yaml
Command executed, exit code: 0.
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 cluster-cloud-director => (version: "0.4.4-40ddaecc9cb3a4c88ad897026674fda5f016c4dc", path: "./helm/cluster-cloud-director")
------------------------------------------------------------------------------------------------------------------------

"cluster-catalog" has been added to your repositories
"cluster-test-catalog" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "cluster-catalog" chart repository
...Successfully got an update from the "cluster-test-catalog" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading cluster-shared from repo https://giantswarm.github.io/cluster-catalog
Deleting outdated charts
Linting chart 'cluster-cloud-director => (version: "0.4.4-40ddaecc9cb3a4c88ad897026674fda5f016c4dc", path: "./helm/cluster-cloud-director")'
Validating /root/project/helm/cluster-cloud-director/Chart.yaml...
Validation success! 👍

Linting chart with values file 'helm/cluster-cloud-director/ci/ci-values.yaml'...

==> Linting ./helm/cluster-cloud-director
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
coalesce.go:223: warning: destination for nodePools is a table. Ignoring non-table value ([])
coalesce.go:175: warning: skipped value for cluster-cloud-director.nodePools: Not a table.
coalesce.go:175: warning: skipped value for cluster-cloud-director.nodePools: Not a table.
coalesce.go:175: warning: skipped value for cluster-cloud-director.nodePools: Not a table.
------------------------------------------------------------------------------------------------------------------------
 ✔︎ cluster-cloud-director => (version: "0.4.4-40ddaecc9cb3a4c88ad897026674fda5f016c4dc", path: "./helm/cluster-cloud-director")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
Running build step for KubeLinter
```

</details>