### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ workflows:
           requires:
             - run-tests
             - augment-circleci-dockerfile
-            - push-app-build-suite-to-quay
           filters:
             # Needed to trigger job also on git tag.
             tags:
@@ -56,7 +55,7 @@ jobs:
           command: |
             echo -n "quay.io/giantswarm/app-build-suite:$(architect project version)" > .docker_image_name
       - run:
-          name: augment circleci.Dockerfile
+          name: Augment circleci.Dockerfile
           command: |
             CURRENT_TAG="$(cat .docker_image_name)"
             sed -i -e "s|FROM changeme|FROM ${CURRENT_TAG}|" circleci.Dockerfile
@@ -85,6 +84,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Publish Release on GitHub"
+          name: Publish Release on GitHub
           command: |
             ghr -t ${ARCHITECT_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./dabs.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ workflows:
           name: push-to-registries
           requires:
             - run-tests
-            - augment-circleci-dockerfile
           filters:
             # Needed to trigger job also on git tag.
             tags:
@@ -34,16 +33,28 @@ workflows:
             tags:
               only: /^v.*/
 
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries-augmented
+          requires:
+            - run-tests
+            - augment-circleci-dockerfile
+          dockerfile: "./circleci.Dockerfile"
+          tag-suffix: "-circleci"
+          filters:
+            # Needed to trigger job also on git tag.
+            tags:
+              only: /^v.*/
+
       - publish-github-release:
           name: publish-github-release-for-dabs
           requires:
-            - push-to-registries
+            - push-to-registries-augmented
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^v.*/
-
 
 jobs:
   augment-circleci-dockerfile:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.35.1
+  architect: giantswarm/architect@4.35.5
   codecov: codecov/codecov@3.3.0
 
 workflows:
@@ -14,14 +14,13 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          name: push-app-build-suite-to-quay
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
           requires:
             - run-tests
-          context: architect
-          image: "quay.io/giantswarm/app-build-suite"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
+            - augment-circleci-dockerfile
+            - push-app-build-suite-to-quay
           filters:
             # Needed to trigger job also on git tag.
             tags:
@@ -30,31 +29,16 @@ workflows:
       - augment-circleci-dockerfile:
           name: augment-circleci-dockerfile
           requires:
-            - push-app-build-suite-to-quay
+            - push-to-registries
           filters:
             # Needed to trigger job also on git tag.
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          name: push-app-build-suite-circle-ci-to-quay
-          requires:
-            - push-app-build-suite-to-quay
-            - augment-circleci-dockerfile
-          context: architect
-          image: "quay.io/giantswarm/app-build-suite"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
-          dockerfile: "./circleci.Dockerfile"
-          tag-suffix: "-circleci"
-          filters:
-            # Needed to trigger job also on git tag.
-            tags:
-              only: /^v.*/
       - publish-github-release:
           name: publish-github-release-for-dabs
           requires:
-            - push-app-build-suite-circle-ci-to-quay
+            - push-to-registries
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- Double-check the job dependecies (`requires`).
- Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- Update the changelog if you think this deserves a mention.
- Approve and merge this PR once it's ready. No need to wait for the author in this case.
- Get this done until 1st of December, so that we can move on with follow-up steps.