### PR TITLE
ci(circleci-image): ship cosign so architect-orb chart signing works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ## [Unreleased]
 
+### Added
+
+- The `-circleci` image variant now ships `cosign` (pinned via `COSIGN_VER` build arg, Renovate-tracked against `sigstore/cosign` GitHub releases, SHA-256 verified against the upstream `cosign_checksums.txt`). Required by `architect/push-to-app-catalog` since architect-orb v8.2.0 defaulted `sign: true` — without `cosign` on PATH, every chart-publish job using `executor: app-build-suite` fails on `Mint Sigstore OIDC token` with `cosign: command not found`. Closes giantswarm/architect-orb#769.
+
 ## 1.8.0 - 2026-04-14
 
 ### Changed

--- a/circleci.Dockerfile
+++ b/circleci.Dockerfile
@@ -8,6 +8,29 @@ RUN apt-get update && apt-get install -y openssh-client curl jq wget gh
 
 RUN wget https://github.com/Link-/gh-token/releases/download/v2.0.6/linux-amd64 -O /usr/bin/gh-token && chmod 700 /usr/bin/gh-token
 
+# renovate: datasource=github-releases depName=sigstore/cosign
+ARG COSIGN_VER=v3.0.6
+
+# Install cosign for keyless OIDC chart signing in CircleCI. The architect orb's
+# `cosign-prepare` step assumes `cosign` is on PATH; without it, every
+# `push-to-app-catalog` job that uses this executor and the orb's default
+# `sign: true` fails with `cosign: command not found`. SHA-256 verified against
+# the upstream `cosign_checksums.txt` from the same release tag.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in amd64|arm64) ;; *) echo "unsupported arch $arch" >&2; exit 1 ;; esac; \
+    base="https://github.com/sigstore/cosign/releases/download/${COSIGN_VER}"; \
+    curl --silent --show-error --fail --location --retry 5 --retry-delay 2 \
+        -o /tmp/cosign "${base}/cosign-linux-${arch}"; \
+    curl --silent --show-error --fail --location --retry 5 --retry-delay 2 \
+        -o /tmp/cosign_checksums.txt "${base}/cosign_checksums.txt"; \
+    expected="$(awk -v f="cosign-linux-${arch}" '$2 == f {print $1}' /tmp/cosign_checksums.txt)"; \
+    [ -n "$expected" ] || { echo "no checksum for cosign-linux-${arch}" >&2; exit 1; }; \
+    echo "${expected}  /tmp/cosign" | sha256sum -c -; \
+    install -m 0755 /tmp/cosign /usr/local/bin/cosign; \
+    rm -f /tmp/cosign /tmp/cosign_checksums.txt; \
+    cosign version
+
 # Setup ssh config for github.com
 RUN mkdir -p ~/.ssh &&\
     chmod 700 ~/.ssh &&\

--- a/renovate.json5
+++ b/renovate.json5
@@ -30,6 +30,7 @@
       customType: 'regex',
       managerFilePatterns: [
         '/^Dockerfile$/',
+        '/^circleci\\.Dockerfile$/',
       ],
       matchStrings: [
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .+_VER=(?<currentValue>.*)\\s',


### PR DESCRIPTION
## Summary

architect-orb v8.2.0 defaulted `sign: true` on `architect/push-to-app-catalog`. The `-circleci` image variant (the tag the orb's `app-build-suite` executor pulls) doesn't ship `cosign`, so every chart-publish job using `executor: app-build-suite` now fails on `Mint Sigstore OIDC token` with `cosign: command not found`. Five Bumblebee repos worked around this with `sign: false`, leaving public charts unsigned.

This PR adds `cosign` to the `-circleci` image so the default signing path works.

Closes giantswarm/architect-orb#769.

## Changes

- `circleci.Dockerfile`: install the official static `cosign-linux-${dpkg-arch}` into `/usr/local/bin/cosign`, SHA-256-verified against the upstream `cosign_checksums.txt` from the same release tag. Pinned via `ARG COSIGN_VER` with the standard `# renovate: datasource=github-releases depName=sigstore/cosign` marker — same pattern as the base `Dockerfile`'s `HELM_VER` / `CT_VER` / `KUBELINTER_VER`.
- `renovate.json5`: `customManager.managerFilePatterns` extended to also match `circleci.Dockerfile`.
- Base `Dockerfile` untouched — `cosign` lands only in the `-circleci` variant.

## Verification

`docker build -f circleci.Dockerfile` succeeds; `cosign version --json` inside the resulting image reports `v3.0.6` at `/usr/local/bin/cosign`.

## Downstream cleanup

After this releases, the orb's executor pin bumps to the new tag, and each consumer's orb pin bumps, these workaround PRs can drop their `sign: false` line:

- klaus #263
- klaus-gateway #48
- mcp-capi #122
- mcp-kubernetes #424
- mcp-prometheus #158