### PR TITLE
fix: stringify boolean restriction values in chart annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ## [Unreleased]
 
+### Fixed
+
+- Stringify boolean values from the `restrictions:` block in `Chart.yaml` when lifting them into chart annotations. Previously `clusterSingleton: true` / `gpuInstances: false` produced annotation values typed as Python `bool`, which the `gs_metadata_chart_schema.yaml` yamale schema rejects with `'True' is not a str` / `'False' is not a str`.
+
 ## [1.8.1] - 2026-05-19
 
 ### Added

--- a/app_build_suite/build_steps/helm_chart_metadata_builder.py
+++ b/app_build_suite/build_steps/helm_chart_metadata_builder.py
@@ -147,10 +147,12 @@ class HelmChartMetadataBuilder(BuildStep):
                 return None
         return None
 
-    def _format_restriction_value(self, value: Any) -> Any:
+    def _format_restriction_value(self, value: Any) -> str:
         if isinstance(value, list):
             return ",".join(str(v) for v in value)
-        return value
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
 
     def _find_git_repo_root(self, chart_dir: str) -> Optional[str]:
         current = os.path.abspath(chart_dir)

--- a/tests/build_steps/test_helm.py
+++ b/tests/build_steps/test_helm.py
@@ -343,6 +343,18 @@ def test_annotation_conversion_with_restrictions(
         step.run(config, context)
 
 
+def test_format_restriction_value_stringifies_booleans() -> None:
+    """Annotation values must be strings to satisfy `gs_metadata_chart_schema.yaml`."""
+    step = HelmChartMetadataBuilder()
+
+    assert step._format_restriction_value(True) == "true"
+    assert step._format_restriction_value(False) == "false"
+    assert isinstance(step._format_restriction_value(True), str)
+    assert isinstance(step._format_restriction_value(False), str)
+    assert step._format_restriction_value("kube-system") == "kube-system"
+    assert step._format_restriction_value(["aws", "azure"]) == "aws,azure"
+
+
 def test_annotation_conversion_mixed_formats(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test conversion when annotations are in mixed formats."""
     step = HelmChartMetadataBuilder()


### PR DESCRIPTION
## What

`HelmChartMetadataBuilder._format_restriction_value` now always returns `str`. Boolean `restrictions:` values (`clusterSingleton`, `namespaceSingleton`, `gpuInstances`) are rendered as lowercase `"true"` / `"false"` instead of being passed through as Python `bool`.

## Why

`pre_run` enforces that those three keys are bools, and `build_chart_yaml_annotations` lifts them into chart annotations. The annotations are then validated against `resources/ct_schemas/gs_metadata_chart_schema.yaml`, which declares values as `map(str(), str())`. Yamale rejects bools:

```
annotations.io.giantswarm.application.restrictions.cluster-singleton: 'True' is not a str.
annotations.io.giantswarm.application.restrictions.gpu-instances: 'False' is not a str.
```

Reproduced on giantswarm/azure-cloud-node-manager-app#133. Helm annotations are `map[string]string` regardless, so stringifying is the right contract.

## Change

- `_format_restriction_value`: return `"true"` / `"false"` for bools; `str(value)` for all other scalars. Existing list-joining behaviour preserved.
- Regression test `test_format_restriction_value_stringifies_booleans` — asserts both value and `str` type. Fails without the fix.
- CHANGELOG `[Unreleased] -> Fixed` entry.

The existing `test_annotation_conversion_with_restrictions` (lines 311-334) already expected string values, so this fix aligns runtime behaviour with the test contract.