### PR TITLE
chore(renovate): migrate to renovate-presets default.json5

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,11 +1,10 @@
 {
   extends: [
-    'config:recommended',
+    'github>giantswarm/renovate-presets:default.json5',
   ],
   labels: [
     'dependencies',
   ],
-  assigneesFromCodeOwners: true,
   packageRules: [
     {
       matchUpdateTypes: [
@@ -16,24 +15,15 @@
       automerge: true,
     },
   ],
-  dependencyDashboard: true,
-  ignorePaths: [
-    '.github/workflows/zz_generated.*',
-    '.github/workflows/codeql-analysis.yml',
-  ],
-  ignoreDeps: [
-    'zricethezav/gitleaks-action',
-    'actions/setup-go',
-  ],
   customManagers: [
     {
       customType: 'regex',
       managerFilePatterns: [
         '/^Dockerfile$/',
-        '/^circleci\\.Dockerfile$/',
+        '/^circleci\.Dockerfile$/',
       ],
       matchStrings: [
-        'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .+_VER=(?<currentValue>.*)\\s',
+        'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\sARG .+_VER=(?<currentValue>.*)\s',
       ],
       versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
     },


### PR DESCRIPTION
Replaces `config:recommended` with `github>giantswarm/renovate-presets:default.json5`.

Removed as now covered by default.json5:
- `dependencyDashboard`
- `assigneesFromCodeOwners`
- `ignorePaths` (.github/workflows/zz_generated.*, codeql-analysis.yml)
- `ignoreDeps` (actions/setup-go, zricethezav/gitleaks-action)

Kept as repo-specific:
- `labels: ['dependencies']` (intentionally omits the `renovate` label that default adds)
- `packageRules` (automerge patch/pin/digest)
- `customManagers` (Dockerfile and circleci.Dockerfile ARG regex)