### PR TITLE
feat(validator): render chart and reject duplicate YAML keys (HelmTemplateValidator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ## [Unreleased]
 
+### Added
+
+- New `HelmTemplateValidator` build step: renders the chart with `helm template` and fails the build on YAML
+  syntax errors or duplicate mapping keys in the rendered manifests (Helm and Kubernetes silently keep only
+  the last value of a duplicated key, dropping configuration). Enabled by default; disable with
+  `--disable-helm-template-validator`, and pass extra values files for charts that don't render with defaults
+  via `--helm-template-extra-values`. Error messages point to the originating template file and line.
+
+### Fixed
+
+- The `hello-world-app` example chart no longer renders a duplicated `helm.sh/chart` label (found by the new
+  `HelmTemplateValidator` step).
+
 ## [2.1.3] - 2026-06-09
 
 ### Changed

--- a/app_build_suite/build_steps/helm.py
+++ b/app_build_suite/build_steps/helm.py
@@ -10,6 +10,7 @@ from app_build_suite.build_steps.helm_chart_builder import HelmChartBuilder
 from app_build_suite.build_steps.helm_chart_metadata_builder import HelmChartMetadataBuilder
 from app_build_suite.build_steps.helm_chart_metadata_finalizer import HelmChartMetadataFinalizer
 from app_build_suite.build_steps.helm_chart_tool_linter import HelmChartToolLinter
+from app_build_suite.build_steps.helm_template_validator import HelmTemplateValidator
 from app_build_suite.build_steps.helm_chart_yaml_restorer import HelmChartYAMLRestorer
 from app_build_suite.build_steps.helm_version_setter import HelmVersionSetter
 from app_build_suite.build_steps.helm_home_url_setter import HelmHomeUrlSetter
@@ -35,6 +36,7 @@ class HelmBuildFilteringPipeline(BuildStepsFilteringPipeline):
                 HelmRequirementsUpdater(),
                 HelmChartToolLinter(),
                 KubeLinter(),
+                HelmTemplateValidator(),
                 HelmChartBuilder(),
                 HelmChartMetadataFinalizer(),
                 HelmChartYAMLRestorer(),

--- a/app_build_suite/build_steps/helm_template_validator.py
+++ b/app_build_suite/build_steps/helm_template_validator.py
@@ -1,0 +1,119 @@
+"""Build step: renders the chart with 'helm template' and validates the output YAML."""
+
+import argparse
+import logging
+import os
+from typing import Set
+
+import configargparse
+import yaml
+from step_exec_lib.errors import ValidationError
+from step_exec_lib.steps import BuildStep
+from step_exec_lib.types import Context, StepType
+from step_exec_lib.utils.processes import run_and_log
+
+from app_build_suite.build_steps.steps import STEP_VALIDATE
+from app_build_suite.errors import BuildError
+from app_build_suite.utils.yaml_strict import DuplicateKeyError, UniqueKeyLoader, find_nearest_source
+
+logger = logging.getLogger(__name__)
+
+
+class HelmTemplateValidator(BuildStep):
+    """
+    Renders the chart with 'helm template' and validates that the rendered manifests
+    are parseable YAML without duplicate mapping keys (which helm and Kubernetes
+    silently resolve by keeping the last value, dropping configuration).
+    """
+
+    _helm_bin = "helm"
+    _min_helm_version = "3.2.0"
+    _max_helm_version = "4.0.0"
+    _release_name = "abs-validation"
+
+    @property
+    def steps_provided(self) -> Set[StepType]:
+        return {STEP_VALIDATE}
+
+    def initialize_config(self, config_parser: configargparse.ArgParser) -> None:
+        config_parser.add_argument(
+            "--disable-helm-template-validator",
+            required=False,
+            default=False,
+            action="store_true",
+            help="Disable rendering the chart with 'helm template' and validating the output YAML.",
+        )
+        config_parser.add_argument(
+            "--helm-template-extra-values",
+            required=False,
+            action="append",
+            help="Path to an extra values file passed to 'helm template' as '--values'. Use for charts that"
+            " don't render with default values only (e.g. templates using 'required'). Can be used multiple"
+            " times.",
+        )
+
+    def pre_run(self, config: argparse.Namespace) -> None:
+        """
+        Checks if the required version of helm is installed and the configured values files exist.
+        :param config: the config object
+        :return: None
+        """
+        if config.disable_helm_template_validator:
+            logger.debug("Helm template validation is disabled, skipping pre-run.")
+            return
+        self._assert_binary_present_in_path(self._helm_bin)
+        run_res = run_and_log([self._helm_bin, "version"], capture_output=True)  # nosec
+        version_line = run_res.stdout.splitlines()[0]
+        prefix = "version.BuildInfo"
+        if version_line.startswith(prefix):
+            version_line = version_line[len(prefix) :].strip("{}")
+        else:
+            raise ValidationError(self.name, f"Can't parse '{self._helm_bin}' version number.")
+        version_entries = version_line.split(",")[0]
+        version = version_entries.split(":")[1].strip('"')
+        self._assert_version_in_range(self._helm_bin, version, self._min_helm_version, self._max_helm_version)
+        extra_values = config.helm_template_extra_values or []
+        for i, values_file in enumerate(extra_values):
+            if not os.path.isabs(values_file):
+                extra_values[i] = values_file = os.path.join(os.getcwd(), values_file)
+            if not os.path.isfile(values_file):
+                raise ValidationError(
+                    self.name,
+                    f"Values file '{values_file}' configured with '--helm-template-extra-values' doesn't exist.",
+                )
+
+    def run(self, config: argparse.Namespace, _: Context) -> None:
+        if config.disable_helm_template_validator:
+            logger.info("Helm template validation is disabled, skipping.")
+            return
+        args = [
+            self._helm_bin,
+            "template",
+            self._release_name,
+            config.chart_dir,
+            "--include-crds",
+        ]
+        for values_file in config.helm_template_extra_values or []:
+            args += ["--values", values_file]
+        logger.info("Rendering the chart with 'helm template' to validate the output.")
+        run_res = run_and_log(args, capture_output=True)  # nosec, input params checked above in pre_run
+        if run_res.returncode != 0:
+            logger.error(f"{self._helm_bin} template run failed with exit code {run_res.returncode}")
+            for line in run_res.stderr.splitlines():
+                logger.error(line)
+            raise BuildError(self.name, "'helm template' rendering failed")
+        rendered = run_res.stdout
+        try:
+            doc_count = sum(1 for _ in yaml.load_all(rendered, Loader=UniqueKeyLoader))  # nosec, safe subclass
+        except DuplicateKeyError as e:
+            source = find_nearest_source(rendered, e.line)
+            in_template = f" (template: '{source}')" if source else ""
+            raise BuildError(self.name, f"Duplicate YAML key in the rendered chart{in_template}: {e}")
+        except yaml.MarkedYAMLError as e:
+            line = e.problem_mark.line + 1 if e.problem_mark else 0
+            source = find_nearest_source(rendered, line) if line else None
+            in_template = f" (template: '{source}')" if source else ""
+            raise BuildError(self.name, f"Invalid YAML in the rendered chart{in_template}: {e}")
+        except yaml.YAMLError as e:
+            raise BuildError(self.name, f"Invalid YAML in the rendered chart: {e}")
+        logger.info(f"Rendered chart is valid YAML ({doc_count} documents, no duplicate keys).")

--- a/app_build_suite/utils/yaml_strict.py
+++ b/app_build_suite/utils/yaml_strict.py
@@ -1,0 +1,47 @@
+"""Strict YAML loading helpers that fail on duplicate mapping keys.
+
+PyYAML's SafeLoader silently keeps the last value when a mapping key is duplicated,
+which for rendered Helm manifests means silently dropped configuration.
+"""
+
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+class DuplicateKeyError(yaml.YAMLError):
+    def __init__(self, message: str, line: int):
+        super().__init__(message)
+        self.line = line
+        """1-based line of the duplicate key, relative to the parsed stream."""
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> Dict[Any, Any]:
+        seen: Dict[Any, yaml.nodes.Node] = {}
+        for key_node, _ in node.value:
+            key = self.construct_object(key_node, deep=True)
+            try:
+                hash(key)
+            except TypeError:
+                # unhashable keys are reported by SafeLoader itself
+                continue
+            if key in seen:
+                raise DuplicateKeyError(
+                    f"duplicate key '{key}' at line {key_node.start_mark.line + 1},"
+                    f" column {key_node.start_mark.column + 1}"
+                    f" (first defined at line {seen[key].start_mark.line + 1})",
+                    key_node.start_mark.line + 1,
+                )
+            seen[key] = key_node
+        return super().construct_mapping(node, deep)
+
+
+def find_nearest_source(rendered: str, line_no: int) -> Optional[str]:
+    """Map a 1-based line in 'helm template' output back to the originating template file
+    using the '# Source: <path>' comments helm emits at the start of each document."""
+    lines = rendered.splitlines()
+    for line in reversed(lines[: min(line_no, len(lines))]):
+        if line.startswith("# Source: "):
+            return line[len("# Source: ") :].strip()
+    return None

--- a/docs/helm-build-pipeline.md
+++ b/docs/helm-build-pipeline.md
@@ -60,7 +60,7 @@ Helm build pipeline executes in sequence the following set of steps:
     - Only writes if changes were made by previous steps (HelmVersionSetter, HelmHomeUrlSetter, or
       HelmChartMetadataBuilder)
     - Uses `yaml.dump` which may reformat the file (removes comments, reorders keys)
-    - The original formatting is preserved by HelmChartYAMLRestorer (step 13) which restores from the backup
+    - The original formatting is preserved by HelmChartYAMLRestorer (step 14) which restores from the backup
     - config options: none
 7. GiantSwarmHelmValidator: runs simple validation rules against the chart source files. Checks for rules we
    want to enforce as company policy.
@@ -112,13 +112,24 @@ Helm build pipeline executes in sequence the following set of steps:
     configuration.
     - config options:
         - `--kubelinter-config`: path to optional 'kube-linter' config file
-11. HelmChartBuilder: this step does the actual chart build using Helm by running `helm package`.
+11. HelmTemplateValidator: renders the chart with `helm template` and validates that the rendered manifests
+    are parseable YAML without duplicate mapping keys. Duplicate keys are dangerous because Helm and
+    Kubernetes silently keep only the last value, dropping the earlier configuration. Error messages include
+    the originating template file (from `helm template`'s `# Source:` comments) and the line of both the
+    duplicate and the first occurrence of the key. Rendering happens fully offline with the chart's default
+    `values.yaml` — no cluster is needed (`--validate` is not used).
+    - config options:
+        - `--disable-helm-template-validator`: disable this step completely
+        - `--helm-template-extra-values`: path to an extra values file passed to `helm template` as
+          `--values`; use it for charts that don't render with default values only (e.g. templates using
+          `required`). Can be given multiple times.
+12. HelmChartBuilder: this step does the actual chart build using Helm by running `helm package`.
     - config options:
         - `--destination`: path of a directory to store the packaged Helm chart tgz
-12. HelmChartMetadataFinalizer: completes and writes the metadata files gathered by HelmChartMetadataBuilder.
+13. HelmChartMetadataFinalizer: completes and writes the metadata files gathered by HelmChartMetadataBuilder.
     - Creates the `<chart>-<version>.tgz-meta/` directory with metadata files
     - config options: none
-13. HelmChartYAMLRestorer: restores the original `Chart.yaml` file from the `.back` backup created by
+14. HelmChartYAMLRestorer: restores the original `Chart.yaml` file from the `.back` backup created by
     ChartYamlWriter.
     - Only restores if changes were made during the build
     - Can be disabled to keep the modified Chart.yaml

--- a/examples/apps/hello-world-app/templates/_helpers.yaml
+++ b/examples/apps/hello-world-app/templates/_helpers.yaml
@@ -37,7 +37,6 @@ Common labels
 helm.sh/chart: {{ include "hello-world-app.chart" . }}
 app: "{{ template "hello-world-app.name" . }}"
 app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-helm.sh/chart: "{{ template "hello-world-app.chart" . }}"
 giantswarm.io/service-type: "managed"
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "honeybadger" | quote }}
 {{ include "hello-world-app.selectorLabels" . }}

--- a/tests/build_steps/test_helm_template_validator.py
+++ b/tests/build_steps/test_helm_template_validator.py
@@ -1,0 +1,149 @@
+import os
+import unittest.mock
+from typing import cast
+
+import pytest
+from pytest_mock import MockerFixture
+from step_exec_lib.errors import ValidationError
+
+from app_build_suite.build_steps.helm_template_validator import HelmTemplateValidator
+from app_build_suite.errors import BuildError
+from tests.build_steps.helpers import init_config_for_step
+
+RENDERED_OK = """---
+# Source: my-app/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+---
+# Source: my-app/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+"""
+
+RENDERED_DUPLICATE_KEY = """---
+# Source: my-app/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: my-app
+  labels:
+    team: my-team
+"""
+
+RENDERED_SYNTAX_ERROR = """---
+# Source: my-app/templates/broken.yaml
+key: [unclosed
+"""
+
+
+def _run_validator(mocker: MockerFixture, stdout: str, returncode: int = 0) -> unittest.mock.Mock:
+    run_res = mocker.Mock(name="RunResult")
+    run_res.returncode = returncode
+    run_res.stdout = stdout
+    run_res.stderr = "some helm error" if returncode != 0 else ""
+    run_and_log = mocker.patch(
+        "app_build_suite.build_steps.helm_template_validator.run_and_log",
+        return_value=run_res,
+    )
+    step = HelmTemplateValidator()
+    config = init_config_for_step(step)
+    step.run(config, {})
+    return run_and_log
+
+
+def test_valid_rendered_chart_passes(mocker: MockerFixture) -> None:
+    run_and_log = _run_validator(mocker, RENDERED_OK)
+    args = run_and_log.call_args.args[0]
+    assert args[:3] == ["helm", "template", "abs-validation"]
+    assert "--include-crds" in args
+
+
+def test_duplicate_key_in_rendered_chart_fails(mocker: MockerFixture) -> None:
+    with pytest.raises(BuildError) as excinfo:
+        _run_validator(mocker, RENDERED_DUPLICATE_KEY)
+    assert "Duplicate YAML key" in excinfo.value.msg
+    assert "my-app/templates/deployment.yaml" in excinfo.value.msg
+    assert "duplicate key 'labels'" in excinfo.value.msg
+
+
+def test_syntax_error_in_rendered_chart_fails(mocker: MockerFixture) -> None:
+    with pytest.raises(BuildError) as excinfo:
+        _run_validator(mocker, RENDERED_SYNTAX_ERROR)
+    assert "Invalid YAML" in excinfo.value.msg
+    assert "my-app/templates/broken.yaml" in excinfo.value.msg
+
+
+def test_failed_helm_template_run_fails(mocker: MockerFixture) -> None:
+    with pytest.raises(BuildError) as excinfo:
+        _run_validator(mocker, "", returncode=1)
+    assert "'helm template' rendering failed" in excinfo.value.msg
+
+
+def test_disabled_validator_skips_run(mocker: MockerFixture) -> None:
+    run_and_log = mocker.patch("app_build_suite.build_steps.helm_template_validator.run_and_log")
+    step = HelmTemplateValidator()
+    config = init_config_for_step(step)
+    config.disable_helm_template_validator = True
+    step.pre_run(config)
+    step.run(config, {})
+    run_and_log.assert_not_called()
+
+
+def test_extra_values_files_are_passed_to_helm(mocker: MockerFixture) -> None:
+    run_res = mocker.Mock(name="RunResult")
+    run_res.returncode = 0
+    run_res.stdout = RENDERED_OK
+    run_and_log = mocker.patch(
+        "app_build_suite.build_steps.helm_template_validator.run_and_log",
+        return_value=run_res,
+    )
+    mocker.patch("os.path.isfile", return_value=True)
+    step = HelmTemplateValidator()
+    mocker.patch.object(step, "_assert_binary_present_in_path")
+    mocker.patch.object(step, "_assert_version_in_range")
+    config = init_config_for_step(step)
+    config.helm_template_extra_values = ["extra-values.yaml"]
+    run_res.stdout = 'version.BuildInfo{Version:"v3.21.2"}'
+    step.pre_run(config)
+    run_res.stdout = RENDERED_OK
+    step.run(config, {})
+
+    expected_path = os.path.join(os.getcwd(), "extra-values.yaml")
+    assert config.helm_template_extra_values == [expected_path]
+    args = run_and_log.call_args.args[0]
+    values_idx = args.index("--values")
+    assert args[values_idx + 1] == expected_path
+
+
+def test_missing_extra_values_file_fails_pre_run(mocker: MockerFixture) -> None:
+    run_res = mocker.Mock(name="RunResult")
+    run_res.returncode = 0
+    run_res.stdout = 'version.BuildInfo{Version:"v3.21.2"}'
+    mocker.patch(
+        "app_build_suite.build_steps.helm_template_validator.run_and_log",
+        return_value=run_res,
+    )
+    step = HelmTemplateValidator()
+    mocker.patch.object(step, "_assert_binary_present_in_path")
+    mocker.patch.object(step, "_assert_version_in_range")
+    config = init_config_for_step(step)
+    config.helm_template_extra_values = ["/nonexisting-fhtagn42/values.yaml"]
+    with pytest.raises(ValidationError):
+        step.pre_run(config)
+
+
+def test_step_is_registered_in_helm_pipeline() -> None:
+    from app_build_suite.build_steps.helm import HelmBuildFilteringPipeline
+    from app_build_suite.build_steps.helm_chart_builder import HelmChartBuilder
+
+    pipeline = HelmBuildFilteringPipeline()
+    steps = cast(list, pipeline._pipeline)
+    step_types = [type(s) for s in steps]
+    assert HelmTemplateValidator in step_types
+    # must render before packaging
+    assert step_types.index(HelmTemplateValidator) < step_types.index(HelmChartBuilder)

--- a/tests/utils/test_yaml_strict.py
+++ b/tests/utils/test_yaml_strict.py
@@ -1,0 +1,108 @@
+from typing import List, Optional
+
+import pytest
+import yaml
+
+from app_build_suite.utils.yaml_strict import DuplicateKeyError, UniqueKeyLoader, find_nearest_source
+
+VALID_MULTI_DOC = """---
+# Source: my-app/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+---
+# Source: my-app/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+"""
+
+DUPLICATE_TOP_LEVEL = """apiVersion: v1
+kind: ConfigMap
+kind: Secret
+"""
+
+DUPLICATE_NESTED = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: my-app
+  labels:
+    team: my-team
+"""
+
+DUPLICATE_IN_LIST_ITEM = """spec:
+  containers:
+    - name: main
+      image: img:1
+      name: sidecar
+"""
+
+SAME_KEY_DIFFERENT_DOCS = """---
+kind: ConfigMap
+---
+kind: Secret
+"""
+
+EMPTY_DOCS = "---\n---\n"
+
+SYNTAX_ERROR = "key: [unclosed\nother: 1\n  bad indent: {{\n"
+
+
+def _load_all(document: str) -> List[object]:
+    return list(yaml.load_all(document, Loader=UniqueKeyLoader))
+
+
+def test_valid_multi_doc_loads() -> None:
+    docs = _load_all(VALID_MULTI_DOC)
+    assert len(docs) == 2
+    assert docs[0]["kind"] == "Deployment"  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "document,duplicate_key,dup_line,first_line",
+    [
+        (DUPLICATE_TOP_LEVEL, "kind", 3, 2),
+        (DUPLICATE_NESTED, "labels", 6, 4),
+        (DUPLICATE_IN_LIST_ITEM, "name", 5, 3),
+    ],
+    ids=["top-level", "nested", "in-list-item"],
+)
+def test_duplicate_keys_raise(document: str, duplicate_key: str, dup_line: int, first_line: int) -> None:
+    with pytest.raises(DuplicateKeyError) as excinfo:
+        _load_all(document)
+    assert f"duplicate key '{duplicate_key}'" in str(excinfo.value)
+    assert f"line {dup_line}" in str(excinfo.value)
+    assert f"first defined at line {first_line}" in str(excinfo.value)
+    assert excinfo.value.line == dup_line
+
+
+def test_same_key_in_different_documents_is_fine() -> None:
+    assert len(_load_all(SAME_KEY_DIFFERENT_DOCS)) == 2
+
+
+@pytest.mark.parametrize(
+    "document,expected_docs", [(EMPTY_DOCS, [None, None]), ("", [])], ids=["empty-docs", "empty-stream"]
+)
+def test_empty_documents_are_fine(document: str, expected_docs: List[object]) -> None:
+    assert _load_all(document) == expected_docs
+
+
+def test_syntax_error_raises_marked_yaml_error() -> None:
+    with pytest.raises(yaml.MarkedYAMLError):
+        _load_all(SYNTAX_ERROR)
+
+
+@pytest.mark.parametrize(
+    "line_no,expected_source",
+    [
+        (5, "my-app/templates/deployment.yaml"),
+        (10, "my-app/templates/service.yaml"),
+        (1, None),
+    ],
+    ids=["first-doc", "second-doc", "before-any-source"],
+)
+def test_find_nearest_source(line_no: int, expected_source: Optional[str]) -> None:
+    assert find_nearest_source(VALID_MULTI_DOC, line_no) == expected_source


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3496

## What

New `HelmTemplateValidator` build step (`validate` step type): renders the chart with `helm template <chart_dir> --include-crds` (offline, no cluster — no `--validate`) and parses the full rendered multi-doc stream with a strict PyYAML `SafeLoader` subclass that raises on duplicate mapping keys. Duplicate keys are dangerous because Helm/Kubernetes silently keep only the last value, dropping configuration. YAML syntax errors in the rendered output are caught the same way.

Error messages include the originating template file (recovered from `helm template`'s `# Source:` comments) plus the line/column of the duplicate and the line of its first occurrence.

## Design decisions

- **Fail-hard, enabled by default.** Escape hatches: `--disable-helm-template-validator` (skip the step) and `--helm-template-extra-values <file>` (repeatable, forwarded as `--values`) for charts that don't render with default values (e.g. `required`). A warn-only mode can be added later if rollout pain shows up.
- Positioned after `HelmChartToolLinter` (ct vendors chart dependencies via `helm dependency build`, so `helm template` works for charts with dependencies) and right before `HelmChartBuilder` — the final render gate before packaging.
- Same helm version gate as `HelmChartBuilder` (3.2.0 ≤ v < 4.0.0).

## Proof it works

The new step immediately caught a real bug in this repo: the `hello-world-app` example chart rendered a duplicated `helm.sh/chart` label (`templates/_helpers.yaml` defined it twice in the common-labels helper). Fixed here as well.

## Testing

- Loader unit tests: duplicate keys at top level / nested / in list-item mappings, same key across documents (allowed), empty docs, syntax errors, `# Source:` mapping.
- Step unit tests: pass/duplicate/syntax-error/failed-render paths, disable flag, extra-values handling, pipeline registration and ordering.
- Manual run against the example chart with real helm: renders clean after the fix; with an injected duplicate the build fails naming the template and lines.
- Note: icon-validator and e2e tests need system cairo and were verified via CI (not runnable on the dev host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)