### PR TITLE
fix: don't fail HelmTemplateValidator on YAML 1.1 value and merge tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ## [Unreleased]
 
+### Fixed
+
+- `HelmTemplateValidator` no longer fails on valid manifests containing the YAML 1.1 `value` (`=`) or `merge`
+  (`<<`) tags. PyYAML implements YAML 1.1 and resolves both tags, but `SafeLoader` has no constructor for
+  either, so the post-render parse aborted with "Invalid YAML in the rendered chart" even though
+  `helm template` succeeded and Kubernetes accepts the output. This blocked every chart shipping the upstream
+  prometheus-operator CRDs, whose `AlertmanagerConfig` `matchType` enum contains a bare `=`, and also broke
+  ordinary `<<: *anchor` merge keys that plain `yaml.safe_load` handles. Both now load as plain strings;
+  duplicate-key detection is unchanged. Charts that set `disable-helm-template-validator` to work around this
+  can re-enable the step.
+
 ## [2.2.0] - 2026-07-24
 
 ### Added

--- a/app_build_suite/utils/yaml_strict.py
+++ b/app_build_suite/utils/yaml_strict.py
@@ -37,6 +37,20 @@ class UniqueKeyLoader(yaml.SafeLoader):
         return super().construct_mapping(node, deep)
 
 
+def _construct_scalar_as_str(loader: UniqueKeyLoader, node: yaml.ScalarNode) -> str:
+    return loader.construct_scalar(node)
+
+
+# PyYAML implements YAML 1.1, so it resolves a plain '=' to the 'value' tag and a plain '<<' to the
+# 'merge' tag, but SafeConstructor registers no constructor for either. Anything containing them then
+# fails to load: a bare '=' scalar (e.g. the upstream prometheus-operator AlertmanagerConfig
+# 'matchType' enum), or a '<<' merge key -- which SafeLoader itself handles via flatten_mapping, but
+# construct_mapping above constructs key nodes before that happens. YAML 1.2 dropped both tags;
+# treat them as the plain strings they are.
+UniqueKeyLoader.add_constructor("tag:yaml.org,2002:value", _construct_scalar_as_str)
+UniqueKeyLoader.add_constructor("tag:yaml.org,2002:merge", _construct_scalar_as_str)
+
+
 def find_nearest_source(rendered: str, line_no: int) -> Optional[str]:
     """Map a 1-based line in 'helm template' output back to the originating template file
     using the '# Source: <path>' comments helm emits at the start of each document."""

--- a/tests/build_steps/test_helm_template_validator.py
+++ b/tests/build_steps/test_helm_template_validator.py
@@ -40,6 +40,57 @@ RENDERED_SYNTAX_ERROR = """---
 key: [unclosed
 """
 
+# A bare '=' resolves to the YAML 1.1 'value' tag and a bare '<<' to the 'merge' tag, neither of
+# which SafeConstructor can build. The CRD document is modelled on the upstream
+# prometheus-operator AlertmanagerConfig 'matchType' enum, which is what surfaced this in CI.
+RENDERED_YAML_11_TAGS = """---
+# Source: my-app/crds/crd-alertmanagerconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: alertmanagerconfigs.monitoring.coreos.com
+spec:
+  matchType:
+    enum:
+    - '!='
+    - =
+    - =~
+    - '!~'
+    type: string
+---
+# Source: my-app/templates/alertmanagerconfig.yaml
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: my-app
+spec:
+  route: &defaults
+    groupWait: 30s
+  routes:
+    - <<: *defaults
+      receiver: my-app
+"""
+
+# A real duplicate key in a stream that also contains the value tag. Guards that the tag
+# constructors don't disturb '# Source:' attribution: the error must be blamed on the second
+# document's template, not the CRD the '=' came from.
+RENDERED_VALUE_TAG_WITH_DUPLICATE = """---
+# Source: my-app/crds/crd-alertmanagerconfigs.yaml
+spec:
+  matchType:
+    enum:
+    - =
+---
+# Source: my-app/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: my-app
+  labels:
+    team: my-team
+"""
+
 
 def _run_validator(mocker: MockerFixture, stdout: str, returncode: int = 0) -> unittest.mock.Mock:
     run_res = mocker.Mock(name="RunResult")
@@ -61,6 +112,21 @@ def test_valid_rendered_chart_passes(mocker: MockerFixture) -> None:
     args = run_and_log.call_args.args[0]
     assert args[:3] == ["helm", "template", "abs-validation"]
     assert "--include-crds" in args
+
+
+def test_rendered_chart_with_yaml_11_tags_passes(mocker: MockerFixture) -> None:
+    """A bare '=' scalar and a '<<' merge key are both accepted by Kubernetes, so neither
+    may fail the step."""
+    run_and_log = _run_validator(mocker, RENDERED_YAML_11_TAGS)
+    assert "--include-crds" in run_and_log.call_args.args[0]
+
+
+def test_duplicate_key_is_still_attributed_when_value_tag_present(mocker: MockerFixture) -> None:
+    with pytest.raises(BuildError) as excinfo:
+        _run_validator(mocker, RENDERED_VALUE_TAG_WITH_DUPLICATE)
+    assert "duplicate key 'labels'" in excinfo.value.msg
+    assert "my-app/templates/deployment.yaml" in excinfo.value.msg
+    assert "crd-alertmanagerconfigs.yaml" not in excinfo.value.msg
 
 
 def test_duplicate_key_in_rendered_chart_fails(mocker: MockerFixture) -> None:

--- a/tests/utils/test_yaml_strict.py
+++ b/tests/utils/test_yaml_strict.py
@@ -50,6 +50,37 @@ EMPTY_DOCS = "---\n---\n"
 
 SYNTAX_ERROR = "key: [unclosed\nother: 1\n  bad indent: {{\n"
 
+# The YAML 1.1 'value' tag: a plain '=' scalar. Taken from the upstream prometheus-operator
+# AlertmanagerConfig CRD 'matchType' enum. Only the bare '=' resolves to the tag; '=~' is a
+# plain string, and '!=' / '!~' have to be quoted because a leading '!' reads as a tag.
+VALUE_TAG_ENUM = """enum:
+- '!='
+- =
+- =~
+- '!~'
+"""
+
+# The YAML 1.1 'merge' tag in key position. Plain yaml.safe_load handles this via
+# SafeConstructor.flatten_mapping, so UniqueKeyLoader must not regress it.
+MERGE_KEY = """base: &base
+  a: 1
+child:
+  <<: *base
+  c: 2
+"""
+
+# The same 'merge' tag reached from value position, where flatten_mapping never sees it.
+MERGE_TAG_IN_LIST = """enum:
+- <<
+"""
+
+# A duplicate alongside the tags above, guarding that the fix doesn't weaken detection.
+DUPLICATE_WITH_VALUE_TAG = """enum:
+- =
+kind: ConfigMap
+kind: Secret
+"""
+
 
 def _load_all(document: str) -> List[object]:
     return list(yaml.load_all(document, Loader=UniqueKeyLoader))
@@ -93,6 +124,27 @@ def test_empty_documents_are_fine(document: str, expected_docs: List[object]) ->
 def test_syntax_error_raises_marked_yaml_error() -> None:
     with pytest.raises(yaml.MarkedYAMLError):
         _load_all(SYNTAX_ERROR)
+
+
+@pytest.mark.parametrize(
+    "document,expected_docs",
+    [
+        (VALUE_TAG_ENUM, [{"enum": ["!=", "=", "=~", "!~"]}]),
+        (MERGE_KEY, [{"base": {"a": 1}, "child": {"a": 1, "c": 2}}]),
+        (MERGE_TAG_IN_LIST, [{"enum": ["<<"]}]),
+    ],
+    ids=["value-tag-enum", "merge-key", "merge-tag-in-list"],
+)
+def test_yaml_11_tags_load_without_error(document: str, expected_docs: List[object]) -> None:
+    """PyYAML resolves the YAML 1.1 'value' ('=') and 'merge' ('<<') tags but SafeConstructor
+    registers no constructor for either, so these used to raise ConstructorError."""
+    assert _load_all(document) == expected_docs
+
+
+def test_duplicate_detection_still_works_alongside_value_tag() -> None:
+    with pytest.raises(DuplicateKeyError) as excinfo:
+        _load_all(DUPLICATE_WITH_VALUE_TAG)
+    assert "duplicate key 'kind'" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`HelmTemplateValidator` fails charts that `helm template` renders at exit 0 and Kubernetes accepts.

PyYAML implements YAML 1.1, so `SafeLoader` resolves the `value` (`=`) and `merge` (`<<`) tags, but `SafeConstructor` registers no constructor for either. `UniqueKeyLoader` inherits both and dies during construction, surfacing as `Invalid YAML in the rendered chart`.

Two reachable failure modes:

- **`=`** — any bare `=` scalar. Real trigger: the upstream prometheus-operator `AlertmanagerConfig` `matchType` enum. See https://github.com/giantswarm/kube-prometheus-stack-app/pull/571 for an example failing job.
- **`<<`** — merge keys, which plain `yaml.safe_load` handles fine. `construct_mapping` constructs every key node before `super()` reaches `flatten_mapping`, so the loader was a regression against `SafeLoader`.

## Fix

Register both tags as plain strings on `UniqueKeyLoader`. No change to the build step itself.

These are the only two reachable gaps: auditing `yaml_implicit_resolvers` against `yaml_constructors` leaves a third tag, `yaml` (`^(?:!|&|\*)$`), which is unreachable because a plain scalar can never start with those indicators. `add_constructor` copies into the subclass's own `__dict__`, so global `yaml.safe_load` is untouched.

## Verification

- New tests fail without the fix, pass with it.
- End-to-end with real `helm` against a chart embedding the upstream CRD enum plus a merge key: was the exact CI error, now `Rendered chart is valid YAML`.
- Duplicate-key detection and `# Source:` attribution unchanged, including in a stream that also contains `=`.
- 149 tests pass. `tests/e2e/test_example_app.py` fails on `main` too (`ct lint`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)