### PR TITLE
chore: remove conftest from the circleci image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ## [Unreleased]
 
+### Removed
+
+- `conftest` binary from the `-circleci` image. It was only there for the `helm-conftest` step in
+  architect-orb's `push-to-app-catalog` job, removed in architect-orb v6.3.2. The
+  [deprek8ion](https://github.com/swade1987/deprek8ion) policies it ran have been unmaintained since 2021,
+  and ABS already runs kube-linter over the same manifests. See
+  [roadmap#4066](https://github.com/giantswarm/roadmap/issues/4066).
+
 ### Fixed
 
 - `HelmTemplateValidator` no longer fails on valid manifests containing the YAML 1.1 `value` (`=`) or `merge`

--- a/circleci.Dockerfile
+++ b/circleci.Dockerfile
@@ -1,8 +1,4 @@
-FROM gsoci.azurecr.io/giantswarm/conftest:v0.68.2 AS conftest
-
 FROM gsoci.azurecr.io/giantswarm/app-build-suite:2.2.0
-
-COPY --from=conftest /usr/local/bin/conftest /usr/local/bin/conftest
 
 RUN apt-get update && apt-get install -y openssh-client curl jq wget gh
 


### PR DESCRIPTION
The `-circleci` image carried `conftest` solely for the `helm-conftest` step in architect-orb's `push-to-app-catalog` job. That step was removed in architect-orb v6.3.2 (giantswarm/architect-orb#647), so the binary is dead weight.

This image is the executor `push-to-app-catalog` actually runs on, so it is where the conftest removal really lands — the architect image copy is handled in giantswarm/architect#1391.

The [deprek8ion](https://github.com/swade1987/deprek8ion) policies it ran have been unmaintained since 2021 and only covered Kubernetes API deprecations up to 1.22. ABS already runs kube-linter over the same manifests.

Part of giantswarm/roadmap#4066