### PR TITLE
fix: skip HelmTemplateValidator for library charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), following
 
 ### Fixed
 
+- `HelmTemplateValidator` now skips Helm **library** charts (`type: library` in `Chart.yaml`) instead of
+  failing the build. `helm template` refuses them outright with "library charts are not installable", so
+  every library chart broke on v2.2.0 unless it set `disable-helm-template-validator` by hand. Library charts
+  have no renderable output of their own, so there is nothing for this step to validate. Charts that added
+  `disable-helm-template-validator: true` purely to work around this can drop it again.
+
 - `HelmTemplateValidator` no longer fails on valid manifests containing the YAML 1.1 `value` (`=`) or `merge`
   (`<<`) tags. PyYAML implements YAML 1.1 and resolves both tags, but `SafeLoader` has no constructor for
   either, so the post-render parse aborted with "Invalid YAML in the rendered chart" even though

--- a/app_build_suite/build_steps/helm_template_validator.py
+++ b/app_build_suite/build_steps/helm_template_validator.py
@@ -12,11 +12,14 @@ from step_exec_lib.steps import BuildStep
 from step_exec_lib.types import Context, StepType
 from step_exec_lib.utils.processes import run_and_log
 
+from app_build_suite.build_steps.helm_consts import CHART_YAML, context_key_chart_yaml
 from app_build_suite.build_steps.steps import STEP_VALIDATE
 from app_build_suite.errors import BuildError
 from app_build_suite.utils.yaml_strict import DuplicateKeyError, UniqueKeyLoader, find_nearest_source
 
 logger = logging.getLogger(__name__)
+
+LIBRARY_CHART_TYPE = "library"
 
 
 class HelmTemplateValidator(BuildStep):
@@ -82,9 +85,32 @@ class HelmTemplateValidator(BuildStep):
                     f"Values file '{values_file}' configured with '--helm-template-extra-values' doesn't exist.",
                 )
 
-    def run(self, config: argparse.Namespace, _: Context) -> None:
+    def _is_library_chart(self, config: argparse.Namespace, context: Context) -> bool:
+        """
+        Returns True if the chart is a Helm library chart.
+
+        Prefers the Chart.yaml already parsed into context by `ChartYamlLoader`, but falls back to
+        reading it from disk, so the check also works when only the validate step is requested and
+        the loader hasn't run.
+        """
+        chart_yaml = context.get(context_key_chart_yaml) if context else None
+        if chart_yaml is None:
+            try:
+                with open(os.path.join(config.chart_dir, CHART_YAML), "r") as f:
+                    chart_yaml = yaml.safe_load(f)
+            except (OSError, yaml.YAMLError):
+                # Chart.yaml is validated by other steps; don't fail here, just don't skip.
+                return False
+        return (chart_yaml or {}).get("type") == LIBRARY_CHART_TYPE
+
+    def run(self, config: argparse.Namespace, context: Context) -> None:
         if config.disable_helm_template_validator:
             logger.info("Helm template validation is disabled, skipping.")
+            return
+        if self._is_library_chart(config, context):
+            # `helm template` refuses library charts with "library charts are not installable".
+            # They have no renderable output of their own, so there is nothing to validate.
+            logger.info("Chart is a library chart and cannot be rendered by 'helm template'; skipping.")
             return
         args = [
             self._helm_bin,

--- a/tests/build_steps/test_helm_template_validator.py
+++ b/tests/build_steps/test_helm_template_validator.py
@@ -203,6 +203,72 @@ def test_missing_extra_values_file_fails_pre_run(mocker: MockerFixture) -> None:
         step.pre_run(config)
 
 
+def _run_with_context(mocker: MockerFixture, context: dict) -> unittest.mock.Mock:
+    run_res = mocker.Mock(name="RunResult")
+    run_res.returncode = 0
+    run_res.stdout = RENDERED_OK
+    run_res.stderr = ""
+    run_and_log = mocker.patch(
+        "app_build_suite.build_steps.helm_template_validator.run_and_log",
+        return_value=run_res,
+    )
+    step = HelmTemplateValidator()
+    config = init_config_for_step(step)
+    step.run(config, context)
+    return run_and_log
+
+
+def test_library_chart_is_skipped(mocker: MockerFixture) -> None:
+    """'helm template' rejects library charts ("library charts are not installable"), so the
+    step must skip them instead of failing the build."""
+    run_and_log = _run_with_context(mocker, {"chart_yaml": {"name": "my-lib", "type": "library"}})
+    run_and_log.assert_not_called()
+
+
+def test_application_chart_is_not_skipped(mocker: MockerFixture) -> None:
+    run_and_log = _run_with_context(mocker, {"chart_yaml": {"name": "my-app", "type": "application"}})
+    run_and_log.assert_called_once()
+
+
+def test_chart_without_explicit_type_is_not_skipped(mocker: MockerFixture) -> None:
+    """'type' is optional in Chart.yaml and defaults to 'application'."""
+    run_and_log = _run_with_context(mocker, {"chart_yaml": {"name": "my-app"}})
+    run_and_log.assert_called_once()
+
+
+def test_library_chart_is_detected_from_disk_without_context(mocker: MockerFixture, tmp_path) -> None:
+    """When only the validate step runs, ChartYamlLoader hasn't populated the context, so the
+    chart type has to be read from disk."""
+    (tmp_path / "Chart.yaml").write_text("name: my-lib\ntype: library\n")
+    run_res = mocker.Mock(name="RunResult")
+    run_res.returncode = 0
+    run_res.stdout = RENDERED_OK
+    run_res.stderr = ""
+    run_and_log = mocker.patch(
+        "app_build_suite.build_steps.helm_template_validator.run_and_log",
+        return_value=run_res,
+    )
+    step = HelmTemplateValidator()
+    config = init_config_for_step(step)
+    config.chart_dir = str(tmp_path)
+    step.run(config, {})
+    run_and_log.assert_not_called()
+
+
+def test_unreadable_chart_yaml_does_not_skip(mocker: MockerFixture, tmp_path) -> None:
+    """A missing or broken Chart.yaml is other steps' problem to report; this step must not
+    swallow the validation by silently skipping."""
+    run_and_log = mocker.patch(
+        "app_build_suite.build_steps.helm_template_validator.run_and_log",
+        return_value=mocker.Mock(returncode=0, stdout=RENDERED_OK, stderr=""),
+    )
+    step = HelmTemplateValidator()
+    config = init_config_for_step(step)
+    config.chart_dir = str(tmp_path / "nonexistent")
+    step.run(config, {})
+    run_and_log.assert_called_once()
+
+
 def test_step_is_registered_in_helm_pipeline() -> None:
     from app_build_suite.build_steps.helm import HelmBuildFilteringPipeline
     from app_build_suite.build_steps.helm_chart_builder import HelmChartBuilder

--- a/tests/build_steps/test_helm_template_validator.py
+++ b/tests/build_steps/test_helm_template_validator.py
@@ -1,5 +1,6 @@
 import os
 import unittest.mock
+from pathlib import Path
 from typing import cast
 
 import pytest
@@ -236,7 +237,7 @@ def test_chart_without_explicit_type_is_not_skipped(mocker: MockerFixture) -> No
     run_and_log.assert_called_once()
 
 
-def test_library_chart_is_detected_from_disk_without_context(mocker: MockerFixture, tmp_path) -> None:
+def test_library_chart_is_detected_from_disk_without_context(mocker: MockerFixture, tmp_path: Path) -> None:
     """When only the validate step runs, ChartYamlLoader hasn't populated the context, so the
     chart type has to be read from disk."""
     (tmp_path / "Chart.yaml").write_text("name: my-lib\ntype: library\n")
@@ -255,7 +256,7 @@ def test_library_chart_is_detected_from_disk_without_context(mocker: MockerFixtu
     run_and_log.assert_not_called()
 
 
-def test_unreadable_chart_yaml_does_not_skip(mocker: MockerFixture, tmp_path) -> None:
+def test_unreadable_chart_yaml_does_not_skip(mocker: MockerFixture, tmp_path: Path) -> None:
     """A missing or broken Chart.yaml is other steps' problem to report; this step must not
     swallow the validation by silently skipping."""
     run_and_log = mocker.patch(


### PR DESCRIPTION
## Problem

`HelmTemplateValidator` (new in v2.2.0) runs `helm template` unconditionally. Helm refuses library charts:

```
Running build step for HelmTemplateValidator
Rendering the chart with 'helm template' to validate the output.
Error: library charts are not installable
Error when running build step for HelmTemplateValidator: 'helm template' rendering failed
```

So **every library chart in the org broke on v2.2.0**. There are three top-level ones:

| Chart | State |
|---|---|
| `cluster-shared` | ❌ broken — every PR build fails ([#134](https://github.com/giantswarm/cluster-shared/pull/134)) |
| `kubectl-apply-job` | ⚠️ green only because `disable-helm-template-validator: true` was hand-added to `.abs/main.yaml` |
| `helm-flux-lib` | not yet on 2.2.0 |

That workaround shouldn't be necessary, and it silently disables the validator for good rather than for the one case where it can't apply.

## Fix

Skip the step when `Chart.yaml` has `type: library`. Library charts have no renderable output of their own — there is genuinely nothing for this step to validate, so this is a permanent exemption, not a suppression.

The chart type is read from the `chart_yaml` already parsed into context by `ChartYamlLoader`, falling back to reading `Chart.yaml` from disk so the check also works when only the validate step is requested and the loader hasn't run. An unreadable `Chart.yaml` deliberately does **not** skip — that's other steps' error to report, and swallowing it here would silently drop validation.

## Tests

5 new cases, 135 passing overall:

- library chart → `helm template` not invoked
- `type: application` → invoked
- no explicit `type` (defaults to application) → invoked
- library chart detected from disk with an empty context
- unreadable `Chart.yaml` → still invoked, not skipped

`ruff check` and `ruff format --check` clean at the pinned v0.15.20.

## Follow-up

Once this releases, `kubectl-apply-job` can drop its `disable-helm-template-validator: true`.